### PR TITLE
Add Kamino on-chain loader, risk utils, CLI, sample, and continuation prompt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,21 @@ venv.bak/
 
 
 # End of https://www.gitignore.io/api/python,pycharm
+
+# Node / Playwright MCP
+node_modules/
+package.json
+package-lock.json
+.playwright-mcp/
+
+# Screenshots (test artifacts)
+*.png
+
+# Claude Code
+.claude/
+
+# IDE
+.vscode/
+*.swp
+*.swo
+*~

--- a/CONTINUATION.md
+++ b/CONTINUATION.md
@@ -1,0 +1,54 @@
+# Continuation Prompt for Next Agent
+
+You are continuing work on the Kamino liquidation risk simulator in `/workspace/cryptoLab`.
+The current code can load on-chain obligations via Solana RPC + Anchor IDL, but it still
+needs real program/IDL discovery and a clean end-to-end run against a specific obligation.
+
+## Current status
+- CLI supports JSON input or on-chain loading:
+  - `kamino_sim.py --input <file>`
+  - `kamino_sim.py --obligation <addr> --program-id <id> --idl <idl.json> --rpc-url <rpc>`
+- On-chain loader is in `arblab/kamino_onchain.py` and uses `anchorpy` to decode accounts.
+- Dependencies added: `anchorpy`, `solana` (see `requirements.txt`).
+
+## Goal
+Run the simulator against the user's obligation account:
+`F8ir9FxMgi17DpnLDbkM6mxy5GmS1o8ynmtP73HuHzQL`
+and produce liquidation metrics using real on-chain data.
+
+## What you must do next
+1) **Find the correct Kamino lending program ID**:
+   - Use Solana RPC `getAccountInfo` on the obligation address.
+   - The account `owner` field is the program ID.
+
+2) **Obtain the Anchor IDL JSON for that program**:
+   - Try `anchor idl fetch <program_id> -o kamino_idl.json`.
+   - If that fails, look in Kamino’s GitHub repos for an `idl/` or `target/idl/` JSON.
+   - If the IDL is not published on-chain, you may need to locate a public repo or
+     reach out for the IDL from Kamino’s sources.
+
+3) **Run the CLI**:
+   ```bash
+   python kamino_sim.py \
+     --obligation F8ir9FxMgi17DpnLDbkM6mxy5GmS1o8ynmtP73HuHzQL \
+     --program-id <PROGRAM_ID> \
+     --idl kamino_idl.json \
+     --rpc-url https://api.mainnet-beta.solana.com
+   ```
+   Capture output and confirm collateral/debt entries look reasonable.
+
+4) **If decoding fails**:
+   - Inspect actual account layout and adjust field names in `kamino_onchain.py`.
+   - Key expected fields: obligation `deposits`, `borrows`, reserve `config`, `liquidity`.
+
+## Notes / constraints from previous environment
+- GitHub and some RPC endpoints returned HTTP 403 here; the next environment should
+  have better internet access.
+- Kamino’s token mint (KMNO) is NOT the program ID. You must query the obligation
+  account owner to find the program ID.
+
+## Files to review
+- `arblab/kamino_onchain.py`
+- `arblab/kamino_risk.py`
+- `kamino_sim.py`
+- `requirements.txt`

--- a/arblab/__init__.py
+++ b/arblab/__init__.py
@@ -1,1 +1,3 @@
-import arblab.arb_lab
+"""Utility modules for arbitrage and risk tooling."""
+
+__all__ = []

--- a/arblab/kamino_onchain.py
+++ b/arblab/kamino_onchain.py
@@ -1,0 +1,152 @@
+import base64
+import json
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any, Dict, Iterable, List
+from urllib import request
+
+from arblab.kamino_risk import AccountSnapshot, CollateralPosition, DebtPosition
+
+
+@dataclass(frozen=True)
+class ReserveConfig:
+    symbol: str
+    price: Decimal
+    ltv: Decimal
+    liquidation_threshold: Decimal
+    decimals: int
+
+
+def _post_json(url: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+    body = json.dumps(payload).encode("utf-8")
+    req = request.Request(url, data=body, headers={"Content-Type": "application/json"})
+    with request.urlopen(req, timeout=30) as response:
+        return json.load(response)
+
+
+def _rpc_call(rpc_url: str, method: str, params: Iterable[Any]) -> Dict[str, Any]:
+    payload = {"jsonrpc": "2.0", "id": 1, "method": method, "params": list(params)}
+    response = _post_json(rpc_url, payload)
+    if "error" in response:
+        raise RuntimeError(f"RPC error for {method}: {response['error']}")
+    return response["result"]
+
+
+def _get_account(rpc_url: str, address: str) -> Dict[str, Any]:
+    result = _rpc_call(rpc_url, "getAccountInfo", [address, {"encoding": "base64"}])
+    value = result.get("value")
+    if not value or not value.get("data"):
+        raise ValueError(f"No account data for {address}")
+    data = base64.b64decode(value["data"][0])
+    return {"data": data, "owner": value.get("owner")}
+
+
+def _load_idl(idl_path: str) -> Any:
+    try:
+        from anchorpy import Idl
+    except ImportError as exc:
+        raise ImportError("anchorpy is required for on-chain decoding.") from exc
+    with open(idl_path, "r", encoding="utf-8") as handle:
+        idl_json = json.load(handle)
+    return Idl.from_json(idl_json)
+
+
+def _decode_account(idl: Any, account_name: str, data: bytes) -> Dict[str, Any]:
+    try:
+        from anchorpy.coder.accounts import AccountsCoder
+    except ImportError as exc:
+        raise ImportError("anchorpy is required for on-chain decoding.") from exc
+    coder = AccountsCoder(idl)
+    return coder.decode(account_name, data)
+
+
+def _to_decimal(value: Any) -> Decimal:
+    return Decimal(str(value))
+
+
+def _normalize_amount(raw_amount: int, decimals: int) -> Decimal:
+    return Decimal(raw_amount) / (Decimal(10) ** decimals)
+
+
+def _parse_reserve_config(reserve: Dict[str, Any]) -> ReserveConfig:
+    config = reserve["config"]
+    liquidity = reserve["liquidity"]
+    symbol = liquidity.get("symbol", liquidity.get("mint_pubkey", "UNKNOWN"))
+    price = _to_decimal(liquidity.get("market_price", 0))
+    ltv = _to_decimal(config.get("loan_to_value_ratio", 0)) / Decimal(100)
+    liquidation_threshold = _to_decimal(config.get("liquidation_threshold", 0)) / Decimal(100)
+    decimals = int(liquidity.get("mint_decimals", 0))
+    return ReserveConfig(
+        symbol=symbol,
+        price=price,
+        ltv=ltv,
+        liquidation_threshold=liquidation_threshold,
+        decimals=decimals,
+    )
+
+
+def load_onchain_snapshot(
+    obligation_address: str,
+    program_id: str,
+    rpc_url: str,
+    idl_path: str,
+    obligation_account_name: str = "obligation",
+    reserve_account_name: str = "reserve",
+) -> AccountSnapshot:
+    idl = _load_idl(idl_path)
+    obligation_account = _get_account(rpc_url, obligation_address)
+    if obligation_account["owner"] != program_id:
+        raise ValueError("Obligation account owner does not match the provided program id.")
+    obligation_raw = obligation_account["data"]
+    obligation = _decode_account(idl, obligation_account_name, obligation_raw)
+
+    deposits = obligation.get("deposits", [])
+    borrows = obligation.get("borrows", [])
+    reserve_addresses = {
+        str(entry["deposit_reserve"]) for entry in deposits
+    }.union({str(entry["borrow_reserve"]) for entry in borrows})
+
+    reserve_map: Dict[str, ReserveConfig] = {}
+    for reserve_address in reserve_addresses:
+        reserve_account = _get_account(rpc_url, reserve_address)
+        if reserve_account["owner"] != program_id:
+            raise ValueError(f"Reserve {reserve_address} is not owned by {program_id}.")
+        reserve_raw = reserve_account["data"]
+        reserve = _decode_account(idl, reserve_account_name, reserve_raw)
+        reserve_map[reserve_address] = _parse_reserve_config(reserve)
+
+    collateral_positions: List[CollateralPosition] = []
+    for entry in deposits:
+        reserve_address = str(entry["deposit_reserve"])
+        reserve = reserve_map[reserve_address]
+        deposited_amount = int(entry.get("deposited_amount", 0))
+        amount = _normalize_amount(deposited_amount, reserve.decimals)
+        collateral_positions.append(
+            CollateralPosition(
+                symbol=reserve.symbol,
+                amount=float(amount),
+                price=float(reserve.price),
+                ltv=float(reserve.ltv),
+                liquidation_threshold=float(reserve.liquidation_threshold),
+            )
+        )
+
+    debt_positions: List[DebtPosition] = []
+    for entry in borrows:
+        reserve_address = str(entry["borrow_reserve"])
+        reserve = reserve_map[reserve_address]
+        borrowed_amount = entry.get("borrowed_amount")
+        borrowed_amount_wads = entry.get("borrowed_amount_wads")
+        if borrowed_amount is not None:
+            amount = _normalize_amount(int(borrowed_amount), reserve.decimals)
+        else:
+            amount = _to_decimal(borrowed_amount_wads or 0) / Decimal(10**18)
+        debt_positions.append(
+            DebtPosition(
+                symbol=reserve.symbol,
+                amount=float(amount),
+                price=float(reserve.price),
+            )
+        )
+
+    return AccountSnapshot(collateral=collateral_positions, debt=debt_positions)

--- a/arblab/kamino_recovery.py
+++ b/arblab/kamino_recovery.py
@@ -1,0 +1,83 @@
+"""Pure calculation functions for recovery, auto-loop, and collateral rebalance.
+
+Extracted from kamino_app.py so they can be unit tested independently.
+"""
+
+
+def compute_deficit(total_debt: float, liq_value: float, target_hf: float) -> float:
+    """How much additional liquidation value is needed to reach *target_hf*.
+
+    deficit = target_hf * total_debt - liq_value
+    Positive means recovery action needed; negative means already safe.
+    """
+    return target_hf * total_debt - liq_value
+
+
+def recovery_repay_usd(total_debt: float, liq_value: float, target_hf: float) -> float:
+    """Option A: USD amount of debt to repay to reach *target_hf*.
+
+    repay_usd = total_debt - liq_value / target_hf
+    """
+    if target_hf <= 0:
+        return 0.0
+    return total_debt - liq_value / target_hf
+
+
+def recovery_swap_withdraw(
+    deficit: float,
+    collateral_price: float,
+    target_hf: float,
+    liq_threshold: float,
+    max_amount: float,
+) -> float:
+    """Option B: tokens of collateral to withdraw and swap into debt repayment.
+
+    withdraw = min(deficit / (price * (target_hf - liq_threshold)), max_amount)
+    Returns 0 if target_hf <= liq_threshold (swap can't improve HF).
+    """
+    if target_hf <= liq_threshold or collateral_price <= 0:
+        return 0.0
+    raw = deficit / (collateral_price * (target_hf - liq_threshold))
+    return min(raw, max_amount)
+
+
+def recovery_deposit_tokens(
+    deficit: float,
+    collateral_price: float,
+    liq_threshold: float,
+) -> float:
+    """Option C: tokens of collateral to deposit to reach *target_hf*.
+
+    deposit = deficit / (price * liq_threshold)
+    """
+    if collateral_price <= 0 or liq_threshold <= 0:
+        return 0.0
+    return deficit / (collateral_price * liq_threshold)
+
+
+def auto_loop_deposit(
+    borrow_amount: float,
+    borrow_price: float,
+    target_price: float,
+) -> float:
+    """Auto-loop: convert borrowed tokens to collateral tokens (USD-neutral swap).
+
+    deposit = (borrow_amount * borrow_price) / target_price
+    """
+    if target_price <= 0:
+        return 0.0
+    return (borrow_amount * borrow_price) / target_price
+
+
+def collateral_rebalance(
+    withdraw_delta: float,
+    source_price: float,
+    target_price: float,
+) -> float:
+    """Collateral rebalance: convert withdrawn collateral to another asset.
+
+    deposit = (abs(withdraw_delta) * source_price) / target_price
+    """
+    if target_price <= 0:
+        return 0.0
+    return (abs(withdraw_delta) * source_price) / target_price

--- a/arblab/kamino_risk.py
+++ b/arblab/kamino_risk.py
@@ -1,0 +1,165 @@
+from dataclasses import dataclass, replace
+from typing import Dict, Iterable, List, Optional
+
+
+@dataclass(frozen=True)
+class CollateralPosition:
+    symbol: str
+    amount: float
+    price: float
+    ltv: float
+    liquidation_threshold: float
+
+    def value(self) -> float:
+        return self.amount * self.price
+
+    def liquidation_value(self) -> float:
+        return self.value() * self.liquidation_threshold
+
+    def borrow_limit_value(self) -> float:
+        return self.value() * self.ltv
+
+
+@dataclass(frozen=True)
+class DebtPosition:
+    symbol: str
+    amount: float
+    price: float
+
+    def value(self) -> float:
+        return self.amount * self.price
+
+
+@dataclass(frozen=True)
+class AccountSnapshot:
+    collateral: List[CollateralPosition]
+    debt: List[DebtPosition]
+
+    def total_collateral_value(self) -> float:
+        return sum(position.value() for position in self.collateral)
+
+    def total_debt_value(self) -> float:
+        return sum(position.value() for position in self.debt)
+
+    def liquidation_value(self) -> float:
+        return sum(position.liquidation_value() for position in self.collateral)
+
+    def borrow_limit(self) -> float:
+        return sum(position.borrow_limit_value() for position in self.collateral)
+
+    def current_ltv(self) -> float:
+        total_collateral = self.total_collateral_value()
+        if total_collateral == 0:
+            return float("inf")
+        return self.total_debt_value() / total_collateral
+
+    def health_factor(self) -> float:
+        total_debt = self.total_debt_value()
+        if total_debt == 0:
+            return float("inf")
+        return self.liquidation_value() / total_debt
+
+    def liquidation_buffer(self) -> float:
+        return self.liquidation_value() - self.total_debt_value()
+
+
+def _find_collateral(snapshot: AccountSnapshot, symbol: str) -> Optional[CollateralPosition]:
+    return next((position for position in snapshot.collateral if position.symbol == symbol), None)
+
+
+def _find_debt(snapshot: AccountSnapshot, symbol: str) -> Optional[DebtPosition]:
+    return next((position for position in snapshot.debt if position.symbol == symbol), None)
+
+
+def liquidation_price_for_collateral(snapshot: AccountSnapshot, symbol: str) -> Optional[float]:
+    target = _find_collateral(snapshot, symbol)
+    if target is None or target.liquidation_threshold == 0 or target.amount == 0:
+        return None
+    other_liquidation_value = sum(
+        position.liquidation_value()
+        for position in snapshot.collateral
+        if position.symbol != symbol
+    )
+    total_debt = snapshot.total_debt_value()
+    required_value = total_debt - other_liquidation_value
+    return max(0.0, required_value / (target.amount * target.liquidation_threshold))
+
+
+def liquidation_price_for_debt(snapshot: AccountSnapshot, symbol: str) -> Optional[float]:
+    target = _find_debt(snapshot, symbol)
+    if target is None or target.amount == 0:
+        return None
+    other_debt_value = sum(
+        position.value()
+        for position in snapshot.debt
+        if position.symbol != symbol
+    )
+    liquidation_value = snapshot.liquidation_value()
+    required_value = liquidation_value - other_debt_value
+    return max(0.0, required_value / target.amount)
+
+
+def liquidation_prices(snapshot: AccountSnapshot) -> Dict[str, Dict[str, Optional[float]]]:
+    collateral_prices = {
+        position.symbol: liquidation_price_for_collateral(snapshot, position.symbol)
+        for position in snapshot.collateral
+    }
+    debt_prices = {
+        position.symbol: liquidation_price_for_debt(snapshot, position.symbol)
+        for position in snapshot.debt
+    }
+    return {"collateral": collateral_prices, "debt": debt_prices}
+
+
+def apply_actions(snapshot: AccountSnapshot, actions: Iterable[Dict[str, float]]) -> AccountSnapshot:
+    collateral = list(snapshot.collateral)
+    debt = list(snapshot.debt)
+
+    for action in actions:
+        action_type = action["type"]
+        symbol = action["symbol"]
+        amount = float(action.get("amount", 0))
+        price = action.get("price")
+
+        if action_type in {"deposit_collateral", "withdraw_collateral"}:
+            position = _find_collateral(AccountSnapshot(collateral, debt), symbol)
+            if position is None:
+                raise ValueError(f"Collateral asset {symbol} not found for action {action_type}.")
+            delta = amount if action_type == "deposit_collateral" else -amount
+            updated = replace(position, amount=position.amount + delta)
+            collateral = [updated if p.symbol == symbol else p for p in collateral]
+        elif action_type in {"borrow", "repay"}:
+            position = _find_debt(AccountSnapshot(collateral, debt), symbol)
+            if position is None:
+                raise ValueError(f"Debt asset {symbol} not found for action {action_type}.")
+            delta = amount if action_type == "borrow" else -amount
+            updated = replace(position, amount=position.amount + delta)
+            debt = [updated if p.symbol == symbol else p for p in debt]
+        elif action_type in {"update_price", "set_price"}:
+            if price is None:
+                raise ValueError(f"Price is required for action {action_type}.")
+            collateral_position = _find_collateral(AccountSnapshot(collateral, debt), symbol)
+            debt_position = _find_debt(AccountSnapshot(collateral, debt), symbol)
+            if collateral_position is None and debt_position is None:
+                raise ValueError(f"Asset {symbol} not found for action {action_type}.")
+            if collateral_position is not None:
+                updated = replace(collateral_position, price=float(price))
+                collateral = [updated if p.symbol == symbol else p for p in collateral]
+            if debt_position is not None:
+                updated = replace(debt_position, price=float(price))
+                debt = [updated if p.symbol == symbol else p for p in debt]
+        else:
+            raise ValueError(f"Unknown action type: {action_type}")
+
+    return AccountSnapshot(collateral=collateral, debt=debt)
+
+
+def scenario_report(snapshot: AccountSnapshot) -> Dict[str, float]:
+    return {
+        "total_collateral_value": snapshot.total_collateral_value(),
+        "total_debt_value": snapshot.total_debt_value(),
+        "borrow_limit": snapshot.borrow_limit(),
+        "current_ltv": snapshot.current_ltv(),
+        "health_factor": snapshot.health_factor(),
+        "liquidation_buffer": snapshot.liquidation_buffer(),
+    }

--- a/kamino_app.py
+++ b/kamino_app.py
@@ -242,6 +242,14 @@ with col_lp2:
 
 st.header("Scenario Simulator")
 
+# Reset: bump a version counter so all widget keys change, creating fresh widgets.
+def _reset_scenario():
+    st.session_state["_scenario_v"] = st.session_state.get("_scenario_v", 0) + 1
+
+st.button("Reset Scenario", on_click=_reset_scenario)
+
+_v = st.session_state.get("_scenario_v", 0)
+
 actions = []
 new_collateral: list[CollateralPosition] = []
 new_debt: list[DebtPosition] = []
@@ -270,7 +278,7 @@ with st.expander("Price Changes", expanded=True):
                 value=current,
                 step=current * 0.01,
                 format=f"$%.{'2' if current >= 1 else '6'}f",
-                key=f"price_{symbol}",
+                key=f"price_{symbol}_v{_v}",
             )
             if abs(new_price - current) > current * 0.001:
                 actions.append({"type": "set_price", "symbol": symbol, "price": new_price})
@@ -285,7 +293,7 @@ with st.expander("Collateral Adjustments"):
             max_value=p.amount * 2.0,
             value=0.0,
             step=max(p.amount * 0.01, 0.001),
-            key=f"coll_{p.symbol}",
+            key=f"coll_{p.symbol}_v{_v}",
         )
         col_b.caption(f"Current: {_fmt(p.amount, 4)}")
         if delta > 0:
@@ -303,7 +311,7 @@ with st.expander("Debt Adjustments"):
             max_value=p.amount * 2.0,
             value=0.0,
             step=max(p.amount * 0.01, 0.01),
-            key=f"debt_{p.symbol}",
+            key=f"debt_{p.symbol}_v{_v}",
         )
         col_b.caption(f"Current: {_fmt(p.amount, 4)}")
         if delta > 0:
@@ -338,7 +346,7 @@ if market_reserves:
                 "Select assets to deposit as collateral",
                 options=[r.symbol for r in available_collateral],
                 format_func=lambda s: f"{s} (${float(collateral_by_symbol[s].price):,.4f}, LTV {float(collateral_by_symbol[s].ltv):.0%})",
-                key="new_coll_select",
+                key=f"new_coll_select_v{_v}",
             )
             for symbol in selected_coll:
                 r = collateral_by_symbol[symbol]
@@ -353,7 +361,7 @@ if market_reserves:
                     value=0.0,
                     step=10.0 ** (-r.decimals) * 1000,
                     format=f"%.{min(r.decimals, 6)}f",
-                    key=f"new_coll_{r.symbol}",
+                    key=f"new_coll_{r.symbol}_v{_v}",
                 )
                 if amount > 0:
                     new_collateral.append(CollateralPosition(
@@ -372,7 +380,7 @@ if market_reserves:
                 "Select assets to borrow",
                 options=[r.symbol for r in available_debt],
                 format_func=lambda s: f"{s} (${float(debt_by_symbol[s].price):,.4f})",
-                key="new_debt_select",
+                key=f"new_debt_select_v{_v}",
             )
             for symbol in selected_debt:
                 r = debt_by_symbol[symbol]
@@ -384,7 +392,7 @@ if market_reserves:
                     value=0.0,
                     step=10.0 ** (-r.decimals) * 1000,
                     format=f"%.{min(r.decimals, 6)}f",
-                    key=f"new_debt_{r.symbol}",
+                    key=f"new_debt_{r.symbol}_v{_v}",
                 )
                 if amount > 0:
                     new_debt.append(DebtPosition(

--- a/kamino_app.py
+++ b/kamino_app.py
@@ -306,6 +306,9 @@ collateral_symbols = [p.symbol for p in snapshot.collateral]
 allocations: list[tuple[str, str, float, float]] = []  # (src, tgt, usd, tgt_amount)
 with st.expander("Collateral Adjustments"):
     for p in snapshot.collateral:
+        if p.amount <= 0:
+            st.caption(f"**{p.symbol}** — fully withdrawn")
+            continue
         col_a, col_b, col_c = st.columns([2, 1, 1])
         delta = col_a.slider(
             f"{p.symbol} collateral change",
@@ -342,6 +345,9 @@ with st.expander("Collateral Adjustments"):
 # Debt adjustments
 with st.expander("Debt Adjustments"):
     for p in snapshot.debt:
+        if p.amount <= 0:
+            st.caption(f"**{p.symbol}** — fully repaid")
+            continue
         col_a, col_b = st.columns([3, 1])
         delta = col_a.slider(
             f"{p.symbol} debt change",

--- a/kamino_app.py
+++ b/kamino_app.py
@@ -1,7 +1,10 @@
 """Kamino Lending liquidation risk simulator - Streamlit UI."""
 
 import os
+from dotenv import load_dotenv
 import streamlit as st
+
+load_dotenv()
 
 from arblab.kamino_onchain import (
     _fetch_jupiter_symbols,
@@ -28,8 +31,9 @@ from arblab.kamino_recovery import (
     recovery_swap_withdraw,
 )
 
-PROGRAM_ID = "KLend2g3cP87fffoy8q1mQqGKjrxjC8boSyAYavgmjD"
-RPC_URL = "https://api.mainnet-beta.solana.com"
+PROGRAM_ID = os.getenv("KAMINO_PROGRAM_ID", "KLend2g3cP87fffoy8q1mQqGKjrxjC8boSyAYavgmjD")
+RPC_URL = os.getenv("SOLANA_RPC_URL", "https://api.mainnet-beta.solana.com")
+DEFAULT_WALLET = os.getenv("DEFAULT_WALLET", "")
 IDL_PATH = os.path.join(os.path.dirname(__file__), "kamino_idl.json")
 
 st.set_page_config(page_title="Kamino Risk Simulator", layout="wide")
@@ -93,7 +97,7 @@ load_mode = st.sidebar.radio(
 if load_mode == "Wallet address":
     wallet = st.sidebar.text_input(
         "Wallet address",
-        value="F8ir9FxMgi17DpnLDbkM6mxy5GmS1o8ynmtP73HuHzQL",
+        value=DEFAULT_WALLET,
     )
     if st.sidebar.button("Load positions"):
         with st.sidebar.status("Fetching obligations...", expanded=True) as status:

--- a/kamino_app.py
+++ b/kamino_app.py
@@ -1,0 +1,363 @@
+"""Kamino Lending liquidation risk simulator - Streamlit UI."""
+
+import os
+import streamlit as st
+
+from arblab.kamino_onchain import find_wallet_obligations, load_onchain_snapshot
+from arblab.kamino_risk import (
+    AccountSnapshot,
+    CollateralPosition,
+    DebtPosition,
+    apply_actions,
+    liquidation_prices,
+    scenario_report,
+)
+
+PROGRAM_ID = "KLend2g3cP87fffoy8q1mQqGKjrxjC8boSyAYavgmjD"
+RPC_URL = "https://api.mainnet-beta.solana.com"
+IDL_PATH = os.path.join(os.path.dirname(__file__), "kamino_idl.json")
+
+st.set_page_config(page_title="Kamino Risk Simulator", layout="wide")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _health_color(hf: float) -> str:
+    if hf == float("inf"):
+        return "green"
+    if hf >= 1.5:
+        return "green"
+    if hf >= 1.1:
+        return "orange"
+    return "red"
+
+
+def _fmt(value: float, decimals: int = 2) -> str:
+    return f"{value:,.{decimals}f}"
+
+
+def _fmt_usd(value: float) -> str:
+    return f"${value:,.2f}"
+
+
+def _pct(value: float) -> str:
+    return f"{value * 100:.1f}%"
+
+
+def _load_snapshot(obligation_address: str) -> AccountSnapshot:
+    return load_onchain_snapshot(
+        obligation_address=obligation_address,
+        program_id=PROGRAM_ID,
+        rpc_url=RPC_URL,
+        idl_path=IDL_PATH,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Sidebar - Position Loading
+# ---------------------------------------------------------------------------
+
+st.sidebar.title("Kamino Risk Sim")
+
+load_mode = st.sidebar.radio(
+    "Load by",
+    ["Wallet address", "Obligation address"],
+    horizontal=True,
+)
+
+if load_mode == "Wallet address":
+    wallet = st.sidebar.text_input(
+        "Wallet address",
+        value="F8ir9FxMgi17DpnLDbkM6mxy5GmS1o8ynmtP73HuHzQL",
+    )
+    if st.sidebar.button("Load positions"):
+        with st.sidebar.status("Fetching obligations...", expanded=True) as status:
+            try:
+                obligations = find_wallet_obligations(wallet, PROGRAM_ID, RPC_URL)
+                if not obligations:
+                    st.sidebar.error("No Kamino obligations found for this wallet.")
+                else:
+                    st.session_state["obligations"] = obligations
+                    # Auto-load the first obligation
+                    st.session_state["selected_obligation"] = obligations[0]
+                    status.update(label=f"Loading obligation data...", state="running")
+                    st.session_state["snapshot"] = _load_snapshot(obligations[0])
+                    status.update(label=f"Found {len(obligations)} obligation(s)", state="complete")
+            except Exception as e:
+                st.sidebar.error(f"Error: {e}")
+
+    obligations = st.session_state.get("obligations", [])
+    if len(obligations) > 1:
+        selected = st.sidebar.selectbox(
+            "Select obligation",
+            obligations,
+            index=obligations.index(st.session_state.get("selected_obligation", obligations[0])),
+        )
+        if selected != st.session_state.get("selected_obligation"):
+            with st.sidebar.status("Loading obligation..."):
+                st.session_state["selected_obligation"] = selected
+                st.session_state["snapshot"] = _load_snapshot(selected)
+
+else:
+    obligation_addr = st.sidebar.text_input("Obligation address", value="")
+    if st.sidebar.button("Load obligation"):
+        if obligation_addr:
+            with st.sidebar.status("Loading obligation data...") as status:
+                try:
+                    st.session_state["snapshot"] = _load_snapshot(obligation_addr)
+                    st.session_state["selected_obligation"] = obligation_addr
+                    st.session_state["obligations"] = [obligation_addr]
+                    status.update(label="Loaded", state="complete")
+                except Exception as e:
+                    st.sidebar.error(f"Error: {e}")
+
+# ---------------------------------------------------------------------------
+# Main content - require a loaded snapshot
+# ---------------------------------------------------------------------------
+
+snapshot: AccountSnapshot | None = st.session_state.get("snapshot")
+
+if snapshot is None:
+    st.title("Kamino Liquidation Risk Simulator")
+    st.info("Enter a wallet or obligation address in the sidebar to get started.")
+    st.stop()
+
+st.title("Kamino Liquidation Risk Simulator")
+
+obligation_label = st.session_state.get("selected_obligation", "")
+if obligation_label:
+    st.caption(f"Obligation: `{obligation_label}`")
+
+
+# ---------------------------------------------------------------------------
+# Section 1 - Current Position Overview
+# ---------------------------------------------------------------------------
+
+st.header("Position Overview")
+
+col_left, col_right = st.columns(2)
+
+with col_left:
+    st.subheader("Collateral")
+    rows = []
+    for p in snapshot.collateral:
+        rows.append({
+            "Asset": p.symbol,
+            "Amount": _fmt(p.amount, 4),
+            "Price": _fmt_usd(p.price),
+            "Value": _fmt_usd(p.value()),
+            "LTV": _pct(p.ltv),
+            "Liq. Threshold": _pct(p.liquidation_threshold),
+        })
+    if rows:
+        st.dataframe(rows, use_container_width=True, hide_index=True)
+        st.markdown(f"**Total collateral: {_fmt_usd(snapshot.total_collateral_value())}**")
+    else:
+        st.write("No collateral positions.")
+
+with col_right:
+    st.subheader("Debt")
+    rows = []
+    for p in snapshot.debt:
+        rows.append({
+            "Asset": p.symbol,
+            "Amount": _fmt(p.amount, 4),
+            "Price": _fmt_usd(p.price),
+            "Value": _fmt_usd(p.value()),
+        })
+    if rows:
+        st.dataframe(rows, use_container_width=True, hide_index=True)
+        st.markdown(f"**Total debt: {_fmt_usd(snapshot.total_debt_value())}**")
+    else:
+        st.write("No debt positions.")
+
+# ---------------------------------------------------------------------------
+# Section 2 - Risk Metrics
+# ---------------------------------------------------------------------------
+
+st.header("Risk Metrics")
+
+report = scenario_report(snapshot)
+hf = report["health_factor"]
+hf_color = _health_color(hf)
+
+m1, m2, m3, m4 = st.columns(4)
+m1.metric("Health Factor", _fmt(hf) if hf != float("inf") else "Safe (no debt)")
+m2.metric("Current LTV", _pct(report["current_ltv"]) if report["current_ltv"] != float("inf") else "N/A")
+m3.metric("Borrow Limit", _fmt_usd(report["borrow_limit"]))
+m4.metric("Liquidation Buffer", _fmt_usd(report["liquidation_buffer"]))
+
+if hf != float("inf"):
+    if hf < 1.1:
+        st.error(f"Health factor is critically low ({_fmt(hf)}). Liquidation risk is high.")
+    elif hf < 1.5:
+        st.warning(f"Health factor is moderate ({_fmt(hf)}). Monitor closely.")
+    else:
+        st.success(f"Health factor is healthy ({_fmt(hf)}).")
+
+# Liquidation prices
+liq_prices = liquidation_prices(snapshot)
+col_lp1, col_lp2 = st.columns(2)
+with col_lp1:
+    st.subheader("Collateral Liquidation Prices")
+    for symbol, price in liq_prices["collateral"].items():
+        if price is not None:
+            current = next((p.price for p in snapshot.collateral if p.symbol == symbol), 0)
+            drop = ((current - price) / current * 100) if current > 0 else 0
+            st.markdown(f"**{symbol}**: {_fmt_usd(price)} (current: {_fmt_usd(current)}, -{_fmt(drop, 1)}% to liq)")
+with col_lp2:
+    st.subheader("Debt Liquidation Prices")
+    for symbol, price in liq_prices["debt"].items():
+        if price is not None:
+            current = next((p.price for p in snapshot.debt if p.symbol == symbol), 0)
+            rise = ((price - current) / current * 100) if current > 0 else 0
+            st.markdown(f"**{symbol}**: {_fmt_usd(price)} (current: {_fmt_usd(current)}, +{_fmt(rise, 1)}% to liq)")
+
+
+# ---------------------------------------------------------------------------
+# Section 3 - Scenario Simulator
+# ---------------------------------------------------------------------------
+
+st.header("Scenario Simulator")
+
+actions = []
+
+# Unique asset symbols across collateral and debt
+all_symbols = list({p.symbol for p in snapshot.collateral} | {p.symbol for p in snapshot.debt})
+all_symbols.sort()
+
+# Price adjustments
+with st.expander("Price Changes", expanded=True):
+    price_cols = st.columns(min(len(all_symbols), 4))
+    for i, symbol in enumerate(all_symbols):
+        col = price_cols[i % len(price_cols)]
+        current = next(
+            (p.price for p in snapshot.collateral if p.symbol == symbol),
+            next((p.price for p in snapshot.debt if p.symbol == symbol), 0),
+        )
+        if current > 0:
+            new_price = col.slider(
+                f"{symbol} price",
+                min_value=current * 0.01,
+                max_value=current * 3.0,
+                value=current,
+                step=current * 0.01,
+                format=f"$%.{'2' if current >= 1 else '6'}f",
+                key=f"price_{symbol}",
+            )
+            if abs(new_price - current) > current * 0.001:
+                actions.append({"type": "set_price", "symbol": symbol, "price": new_price})
+
+# Collateral adjustments
+with st.expander("Collateral Adjustments"):
+    for p in snapshot.collateral:
+        col_a, col_b = st.columns([3, 1])
+        delta = col_a.slider(
+            f"{p.symbol} collateral change",
+            min_value=-p.amount,
+            max_value=p.amount * 2.0,
+            value=0.0,
+            step=max(p.amount * 0.01, 0.001),
+            key=f"coll_{p.symbol}",
+        )
+        col_b.caption(f"Current: {_fmt(p.amount, 4)}")
+        if delta > 0:
+            actions.append({"type": "deposit_collateral", "symbol": p.symbol, "amount": delta})
+        elif delta < 0:
+            actions.append({"type": "withdraw_collateral", "symbol": p.symbol, "amount": abs(delta)})
+
+# Debt adjustments
+with st.expander("Debt Adjustments"):
+    for p in snapshot.debt:
+        col_a, col_b = st.columns([3, 1])
+        delta = col_a.slider(
+            f"{p.symbol} debt change",
+            min_value=-p.amount,
+            max_value=p.amount * 2.0,
+            value=0.0,
+            step=max(p.amount * 0.01, 0.01),
+            key=f"debt_{p.symbol}",
+        )
+        col_b.caption(f"Current: {_fmt(p.amount, 4)}")
+        if delta > 0:
+            actions.append({"type": "borrow", "symbol": p.symbol, "amount": delta})
+        elif delta < 0:
+            actions.append({"type": "repay", "symbol": p.symbol, "amount": abs(delta)})
+
+# Apply scenario
+if actions:
+    try:
+        sim_snapshot = apply_actions(snapshot, actions)
+    except ValueError as e:
+        st.error(f"Invalid scenario: {e}")
+        st.stop()
+
+    sim_report = scenario_report(sim_snapshot)
+    sim_liq = liquidation_prices(sim_snapshot)
+    sim_hf = sim_report["health_factor"]
+
+    st.subheader("Scenario Results")
+
+    s1, s2, s3, s4 = st.columns(4)
+
+    def _delta_str(new: float, old: float) -> str:
+        diff = new - old
+        if abs(diff) < 0.0001:
+            return ""
+        return f"{diff:+.2f}"
+
+    hf_delta = _delta_str(sim_hf, hf) if hf != float("inf") and sim_hf != float("inf") else ""
+    s1.metric(
+        "Health Factor",
+        _fmt(sim_hf) if sim_hf != float("inf") else "Safe",
+        delta=hf_delta or None,
+        delta_color="normal",
+    )
+    ltv_delta = _delta_str(sim_report["current_ltv"], report["current_ltv"]) if report["current_ltv"] != float("inf") else ""
+    s2.metric(
+        "Current LTV",
+        _pct(sim_report["current_ltv"]) if sim_report["current_ltv"] != float("inf") else "N/A",
+        delta=ltv_delta or None,
+        delta_color="inverse",
+    )
+    s3.metric(
+        "Borrow Limit",
+        _fmt_usd(sim_report["borrow_limit"]),
+        delta=_delta_str(sim_report["borrow_limit"], report["borrow_limit"]) or None,
+    )
+    s4.metric(
+        "Liq. Buffer",
+        _fmt_usd(sim_report["liquidation_buffer"]),
+        delta=_delta_str(sim_report["liquidation_buffer"], report["liquidation_buffer"]) or None,
+    )
+
+    if sim_hf != float("inf"):
+        if sim_hf < 1.0:
+            st.error("LIQUIDATION! Health factor is below 1.0 in this scenario.")
+        elif sim_hf < 1.1:
+            st.error(f"Health factor is critically low ({_fmt(sim_hf)}).")
+        elif sim_hf < 1.5:
+            st.warning(f"Health factor is moderate ({_fmt(sim_hf)}).")
+        else:
+            st.success(f"Health factor is healthy ({_fmt(sim_hf)}).")
+
+    # Show updated liquidation prices
+    lp1, lp2 = st.columns(2)
+    with lp1:
+        st.markdown("**Updated Collateral Liquidation Prices**")
+        for symbol, price in sim_liq["collateral"].items():
+            if price is not None:
+                orig = liq_prices["collateral"].get(symbol)
+                delta = f" (was {_fmt_usd(orig)})" if orig and abs(price - orig) > 0.01 else ""
+                st.markdown(f"- {symbol}: {_fmt_usd(price)}{delta}")
+    with lp2:
+        st.markdown("**Updated Debt Liquidation Prices**")
+        for symbol, price in sim_liq["debt"].items():
+            if price is not None:
+                orig = liq_prices["debt"].get(symbol)
+                delta = f" (was {_fmt_usd(orig)})" if orig and abs(price - orig) > 0.01 else ""
+                st.markdown(f"- {symbol}: {_fmt_usd(price)}{delta}")
+else:
+    st.info("Adjust the sliders above to simulate scenarios.")

--- a/kamino_idl.json
+++ b/kamino_idl.json
@@ -1,0 +1,6811 @@
+{
+  "version": "1.13.0",
+  "name": "kamino_lending",
+  "instructions": [
+    {
+      "name": "initLendingMarket",
+      "accounts": [
+        {
+          "name": "lendingMarketOwner",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "lendingMarket",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarketAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "quoteCurrency",
+          "type": {
+            "array": [
+              "u8",
+              32
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "updateLendingMarket",
+      "accounts": [
+        {
+          "name": "lendingMarketOwner",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "lendingMarket",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "mode",
+          "type": "u64"
+        },
+        {
+          "name": "value",
+          "type": {
+            "array": [
+              "u8",
+              72
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "updateLendingMarketOwner",
+      "accounts": [
+        {
+          "name": "lendingMarketOwnerCached",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "lendingMarket",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "initReserve",
+      "accounts": [
+        {
+          "name": "signer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "lendingMarket",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarketAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "reserve",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "reserveLiquidityMint",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "reserveLiquiditySupply",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "feeReceiver",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "reserveCollateralMint",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "reserveCollateralSupply",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "initialLiquiditySource",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "liquidityTokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "collateralTokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "initFarmsForReserve",
+      "accounts": [
+        {
+          "name": "lendingMarketOwner",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "lendingMarket",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarketAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "reserve",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "farmsProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "farmsGlobalConfig",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "farmState",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "farmsVaultAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "mode",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "updateReserveConfig",
+      "accounts": [
+        {
+          "name": "signer",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "globalConfig",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarket",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "reserve",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "mode",
+          "type": {
+            "defined": "UpdateConfigMode"
+          }
+        },
+        {
+          "name": "value",
+          "type": "bytes"
+        },
+        {
+          "name": "skipConfigIntegrityValidation",
+          "type": "bool"
+        }
+      ]
+    },
+    {
+      "name": "redeemFees",
+      "accounts": [
+        {
+          "name": "reserve",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "reserveLiquidityMint",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "reserveLiquidityFeeReceiver",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "reserveSupplyLiquidity",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarket",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarketAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "withdrawProtocolFee",
+      "accounts": [
+        {
+          "name": "globalConfig",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarket",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "reserve",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "reserveLiquidityMint",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarketAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "feeVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "feeCollectorAta",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "seedDepositOnInitReserve",
+      "accounts": [
+        {
+          "name": "signer",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "lendingMarket",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "reserve",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "reserveLiquidityMint",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "reserveLiquiditySupply",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "initialLiquiditySource",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "liquidityTokenProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "socializeLoss",
+      "accounts": [
+        {
+          "name": "riskCouncil",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "obligation",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarket",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "reserve",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "instructionSysvarAccount",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "liquidityAmount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "socializeLossV2",
+      "accounts": [
+        {
+          "name": "socializeLossAccounts",
+          "accounts": [
+            {
+              "name": "riskCouncil",
+              "isMut": false,
+              "isSigner": true
+            },
+            {
+              "name": "obligation",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "lendingMarket",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "reserve",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "instructionSysvarAccount",
+              "isMut": false,
+              "isSigner": false
+            }
+          ]
+        },
+        {
+          "name": "farmsAccounts",
+          "accounts": [
+            {
+              "name": "obligationFarmUserState",
+              "isMut": true,
+              "isSigner": false,
+              "isOptional": true
+            },
+            {
+              "name": "reserveFarmState",
+              "isMut": true,
+              "isSigner": false,
+              "isOptional": true
+            }
+          ]
+        },
+        {
+          "name": "lendingMarketAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "farmsProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "liquidityAmount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "markObligationForDeleveraging",
+      "accounts": [
+        {
+          "name": "riskCouncil",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "obligation",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarket",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "autodeleverageTargetLtvPct",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "refreshReserve",
+      "accounts": [
+        {
+          "name": "reserve",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarket",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "pythOracle",
+          "isMut": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "name": "switchboardPriceOracle",
+          "isMut": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "name": "switchboardTwapOracle",
+          "isMut": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "name": "scopePrices",
+          "isMut": false,
+          "isSigner": false,
+          "isOptional": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "refreshReservesBatch",
+      "accounts": [],
+      "args": [
+        {
+          "name": "skipPriceUpdates",
+          "type": "bool"
+        }
+      ]
+    },
+    {
+      "name": "depositReserveLiquidity",
+      "accounts": [
+        {
+          "name": "owner",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "reserve",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarket",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarketAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "reserveLiquidityMint",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "reserveLiquiditySupply",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "reserveCollateralMint",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userSourceLiquidity",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userDestinationCollateral",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "collateralTokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "liquidityTokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "instructionSysvarAccount",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "liquidityAmount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "redeemReserveCollateral",
+      "accounts": [
+        {
+          "name": "owner",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "lendingMarket",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "reserve",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarketAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "reserveLiquidityMint",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "reserveCollateralMint",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "reserveLiquiditySupply",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userSourceCollateral",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userDestinationLiquidity",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "collateralTokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "liquidityTokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "instructionSysvarAccount",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "collateralAmount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "initObligation",
+      "accounts": [
+        {
+          "name": "obligationOwner",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "feePayer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "obligation",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarket",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "seed1Account",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "seed2Account",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "ownerUserMetadata",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "InitObligationArgs"
+          }
+        }
+      ]
+    },
+    {
+      "name": "initObligationFarmsForReserve",
+      "accounts": [
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "owner",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "obligation",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarketAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "reserve",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "reserveFarmState",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "obligationFarm",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarket",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "farmsProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "mode",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "refreshObligationFarmsForReserve",
+      "accounts": [
+        {
+          "name": "crank",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "baseAccounts",
+          "accounts": [
+            {
+              "name": "obligation",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "lendingMarketAuthority",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "reserve",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "reserveFarmState",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "obligationFarmUserState",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "lendingMarket",
+              "isMut": false,
+              "isSigner": false
+            }
+          ]
+        },
+        {
+          "name": "farmsProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "mode",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "refreshObligation",
+      "accounts": [
+        {
+          "name": "lendingMarket",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "obligation",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "depositObligationCollateral",
+      "accounts": [
+        {
+          "name": "owner",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "obligation",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarket",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "depositReserve",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "reserveDestinationCollateral",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userSourceCollateral",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "instructionSysvarAccount",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "collateralAmount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "depositObligationCollateralV2",
+      "accounts": [
+        {
+          "name": "depositAccounts",
+          "accounts": [
+            {
+              "name": "owner",
+              "isMut": false,
+              "isSigner": true
+            },
+            {
+              "name": "obligation",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "lendingMarket",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "depositReserve",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "reserveDestinationCollateral",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "userSourceCollateral",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "tokenProgram",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "instructionSysvarAccount",
+              "isMut": false,
+              "isSigner": false
+            }
+          ]
+        },
+        {
+          "name": "lendingMarketAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "farmsAccounts",
+          "accounts": [
+            {
+              "name": "obligationFarmUserState",
+              "isMut": true,
+              "isSigner": false,
+              "isOptional": true
+            },
+            {
+              "name": "reserveFarmState",
+              "isMut": true,
+              "isSigner": false,
+              "isOptional": true
+            }
+          ]
+        },
+        {
+          "name": "farmsProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "collateralAmount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "withdrawObligationCollateral",
+      "accounts": [
+        {
+          "name": "owner",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "obligation",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarket",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarketAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "withdrawReserve",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "reserveSourceCollateral",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userDestinationCollateral",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "instructionSysvarAccount",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "collateralAmount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "withdrawObligationCollateralV2",
+      "accounts": [
+        {
+          "name": "withdrawAccounts",
+          "accounts": [
+            {
+              "name": "owner",
+              "isMut": true,
+              "isSigner": true
+            },
+            {
+              "name": "obligation",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "lendingMarket",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "lendingMarketAuthority",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "withdrawReserve",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "reserveSourceCollateral",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "userDestinationCollateral",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "tokenProgram",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "instructionSysvarAccount",
+              "isMut": false,
+              "isSigner": false
+            }
+          ]
+        },
+        {
+          "name": "farmsAccounts",
+          "accounts": [
+            {
+              "name": "obligationFarmUserState",
+              "isMut": true,
+              "isSigner": false,
+              "isOptional": true
+            },
+            {
+              "name": "reserveFarmState",
+              "isMut": true,
+              "isSigner": false,
+              "isOptional": true
+            }
+          ]
+        },
+        {
+          "name": "farmsProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "collateralAmount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "borrowObligationLiquidity",
+      "accounts": [
+        {
+          "name": "owner",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "obligation",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarket",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarketAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "borrowReserve",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "borrowReserveLiquidityMint",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "reserveSourceLiquidity",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "borrowReserveLiquidityFeeReceiver",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userDestinationLiquidity",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "referrerTokenState",
+          "isMut": true,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "instructionSysvarAccount",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "liquidityAmount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "borrowObligationLiquidityV2",
+      "accounts": [
+        {
+          "name": "borrowAccounts",
+          "accounts": [
+            {
+              "name": "owner",
+              "isMut": false,
+              "isSigner": true
+            },
+            {
+              "name": "obligation",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "lendingMarket",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "lendingMarketAuthority",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "borrowReserve",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "borrowReserveLiquidityMint",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "reserveSourceLiquidity",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "borrowReserveLiquidityFeeReceiver",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "userDestinationLiquidity",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "referrerTokenState",
+              "isMut": true,
+              "isSigner": false,
+              "isOptional": true
+            },
+            {
+              "name": "tokenProgram",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "instructionSysvarAccount",
+              "isMut": false,
+              "isSigner": false
+            }
+          ]
+        },
+        {
+          "name": "farmsAccounts",
+          "accounts": [
+            {
+              "name": "obligationFarmUserState",
+              "isMut": true,
+              "isSigner": false,
+              "isOptional": true
+            },
+            {
+              "name": "reserveFarmState",
+              "isMut": true,
+              "isSigner": false,
+              "isOptional": true
+            }
+          ]
+        },
+        {
+          "name": "farmsProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "liquidityAmount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "repayObligationLiquidity",
+      "accounts": [
+        {
+          "name": "owner",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "obligation",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarket",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "repayReserve",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "reserveLiquidityMint",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "reserveDestinationLiquidity",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userSourceLiquidity",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "instructionSysvarAccount",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "liquidityAmount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "repayObligationLiquidityV2",
+      "accounts": [
+        {
+          "name": "repayAccounts",
+          "accounts": [
+            {
+              "name": "owner",
+              "isMut": false,
+              "isSigner": true
+            },
+            {
+              "name": "obligation",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "lendingMarket",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "repayReserve",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "reserveLiquidityMint",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "reserveDestinationLiquidity",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "userSourceLiquidity",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "tokenProgram",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "instructionSysvarAccount",
+              "isMut": false,
+              "isSigner": false
+            }
+          ]
+        },
+        {
+          "name": "farmsAccounts",
+          "accounts": [
+            {
+              "name": "obligationFarmUserState",
+              "isMut": true,
+              "isSigner": false,
+              "isOptional": true
+            },
+            {
+              "name": "reserveFarmState",
+              "isMut": true,
+              "isSigner": false,
+              "isOptional": true
+            }
+          ]
+        },
+        {
+          "name": "lendingMarketAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "farmsProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "liquidityAmount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "repayAndWithdrawAndRedeem",
+      "accounts": [
+        {
+          "name": "repayAccounts",
+          "accounts": [
+            {
+              "name": "owner",
+              "isMut": false,
+              "isSigner": true
+            },
+            {
+              "name": "obligation",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "lendingMarket",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "repayReserve",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "reserveLiquidityMint",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "reserveDestinationLiquidity",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "userSourceLiquidity",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "tokenProgram",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "instructionSysvarAccount",
+              "isMut": false,
+              "isSigner": false
+            }
+          ]
+        },
+        {
+          "name": "withdrawAccounts",
+          "accounts": [
+            {
+              "name": "owner",
+              "isMut": true,
+              "isSigner": true
+            },
+            {
+              "name": "obligation",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "lendingMarket",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "lendingMarketAuthority",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "withdrawReserve",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "reserveLiquidityMint",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "reserveSourceCollateral",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "reserveCollateralMint",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "reserveLiquiditySupply",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "userDestinationLiquidity",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "placeholderUserDestinationCollateral",
+              "isMut": false,
+              "isSigner": false,
+              "isOptional": true
+            },
+            {
+              "name": "collateralTokenProgram",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "liquidityTokenProgram",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "instructionSysvarAccount",
+              "isMut": false,
+              "isSigner": false
+            }
+          ]
+        },
+        {
+          "name": "collateralFarmsAccounts",
+          "accounts": [
+            {
+              "name": "obligationFarmUserState",
+              "isMut": true,
+              "isSigner": false,
+              "isOptional": true
+            },
+            {
+              "name": "reserveFarmState",
+              "isMut": true,
+              "isSigner": false,
+              "isOptional": true
+            }
+          ]
+        },
+        {
+          "name": "debtFarmsAccounts",
+          "accounts": [
+            {
+              "name": "obligationFarmUserState",
+              "isMut": true,
+              "isSigner": false,
+              "isOptional": true
+            },
+            {
+              "name": "reserveFarmState",
+              "isMut": true,
+              "isSigner": false,
+              "isOptional": true
+            }
+          ]
+        },
+        {
+          "name": "farmsProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "repayAmount",
+          "type": "u64"
+        },
+        {
+          "name": "withdrawCollateralAmount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "depositAndWithdraw",
+      "accounts": [
+        {
+          "name": "depositAccounts",
+          "accounts": [
+            {
+              "name": "owner",
+              "isMut": true,
+              "isSigner": true
+            },
+            {
+              "name": "obligation",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "lendingMarket",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "lendingMarketAuthority",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "reserve",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "reserveLiquidityMint",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "reserveLiquiditySupply",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "reserveCollateralMint",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "reserveDestinationDepositCollateral",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "userSourceLiquidity",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "placeholderUserDestinationCollateral",
+              "isMut": false,
+              "isSigner": false,
+              "isOptional": true
+            },
+            {
+              "name": "collateralTokenProgram",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "liquidityTokenProgram",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "instructionSysvarAccount",
+              "isMut": false,
+              "isSigner": false
+            }
+          ]
+        },
+        {
+          "name": "withdrawAccounts",
+          "accounts": [
+            {
+              "name": "owner",
+              "isMut": true,
+              "isSigner": true
+            },
+            {
+              "name": "obligation",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "lendingMarket",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "lendingMarketAuthority",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "withdrawReserve",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "reserveLiquidityMint",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "reserveSourceCollateral",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "reserveCollateralMint",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "reserveLiquiditySupply",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "userDestinationLiquidity",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "placeholderUserDestinationCollateral",
+              "isMut": false,
+              "isSigner": false,
+              "isOptional": true
+            },
+            {
+              "name": "collateralTokenProgram",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "liquidityTokenProgram",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "instructionSysvarAccount",
+              "isMut": false,
+              "isSigner": false
+            }
+          ]
+        },
+        {
+          "name": "depositFarmsAccounts",
+          "accounts": [
+            {
+              "name": "obligationFarmUserState",
+              "isMut": true,
+              "isSigner": false,
+              "isOptional": true
+            },
+            {
+              "name": "reserveFarmState",
+              "isMut": true,
+              "isSigner": false,
+              "isOptional": true
+            }
+          ]
+        },
+        {
+          "name": "withdrawFarmsAccounts",
+          "accounts": [
+            {
+              "name": "obligationFarmUserState",
+              "isMut": true,
+              "isSigner": false,
+              "isOptional": true
+            },
+            {
+              "name": "reserveFarmState",
+              "isMut": true,
+              "isSigner": false,
+              "isOptional": true
+            }
+          ]
+        },
+        {
+          "name": "farmsProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "liquidityAmount",
+          "type": "u64"
+        },
+        {
+          "name": "withdrawCollateralAmount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "depositReserveLiquidityAndObligationCollateral",
+      "accounts": [
+        {
+          "name": "owner",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "obligation",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarket",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarketAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "reserve",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "reserveLiquidityMint",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "reserveLiquiditySupply",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "reserveCollateralMint",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "reserveDestinationDepositCollateral",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userSourceLiquidity",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "placeholderUserDestinationCollateral",
+          "isMut": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "name": "collateralTokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "liquidityTokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "instructionSysvarAccount",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "liquidityAmount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "depositReserveLiquidityAndObligationCollateralV2",
+      "accounts": [
+        {
+          "name": "depositAccounts",
+          "accounts": [
+            {
+              "name": "owner",
+              "isMut": true,
+              "isSigner": true
+            },
+            {
+              "name": "obligation",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "lendingMarket",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "lendingMarketAuthority",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "reserve",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "reserveLiquidityMint",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "reserveLiquiditySupply",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "reserveCollateralMint",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "reserveDestinationDepositCollateral",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "userSourceLiquidity",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "placeholderUserDestinationCollateral",
+              "isMut": false,
+              "isSigner": false,
+              "isOptional": true
+            },
+            {
+              "name": "collateralTokenProgram",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "liquidityTokenProgram",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "instructionSysvarAccount",
+              "isMut": false,
+              "isSigner": false
+            }
+          ]
+        },
+        {
+          "name": "farmsAccounts",
+          "accounts": [
+            {
+              "name": "obligationFarmUserState",
+              "isMut": true,
+              "isSigner": false,
+              "isOptional": true
+            },
+            {
+              "name": "reserveFarmState",
+              "isMut": true,
+              "isSigner": false,
+              "isOptional": true
+            }
+          ]
+        },
+        {
+          "name": "farmsProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "liquidityAmount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "withdrawObligationCollateralAndRedeemReserveCollateral",
+      "accounts": [
+        {
+          "name": "owner",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "obligation",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarket",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarketAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "withdrawReserve",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "reserveLiquidityMint",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "reserveSourceCollateral",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "reserveCollateralMint",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "reserveLiquiditySupply",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userDestinationLiquidity",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "placeholderUserDestinationCollateral",
+          "isMut": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "name": "collateralTokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "liquidityTokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "instructionSysvarAccount",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "collateralAmount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "withdrawObligationCollateralAndRedeemReserveCollateralV2",
+      "accounts": [
+        {
+          "name": "withdrawAccounts",
+          "accounts": [
+            {
+              "name": "owner",
+              "isMut": true,
+              "isSigner": true
+            },
+            {
+              "name": "obligation",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "lendingMarket",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "lendingMarketAuthority",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "withdrawReserve",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "reserveLiquidityMint",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "reserveSourceCollateral",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "reserveCollateralMint",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "reserveLiquiditySupply",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "userDestinationLiquidity",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "placeholderUserDestinationCollateral",
+              "isMut": false,
+              "isSigner": false,
+              "isOptional": true
+            },
+            {
+              "name": "collateralTokenProgram",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "liquidityTokenProgram",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "instructionSysvarAccount",
+              "isMut": false,
+              "isSigner": false
+            }
+          ]
+        },
+        {
+          "name": "farmsAccounts",
+          "accounts": [
+            {
+              "name": "obligationFarmUserState",
+              "isMut": true,
+              "isSigner": false,
+              "isOptional": true
+            },
+            {
+              "name": "reserveFarmState",
+              "isMut": true,
+              "isSigner": false,
+              "isOptional": true
+            }
+          ]
+        },
+        {
+          "name": "farmsProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "collateralAmount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "liquidateObligationAndRedeemReserveCollateral",
+      "accounts": [
+        {
+          "name": "liquidator",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "obligation",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarket",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarketAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "repayReserve",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "repayReserveLiquidityMint",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "repayReserveLiquiditySupply",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "withdrawReserve",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "withdrawReserveLiquidityMint",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "withdrawReserveCollateralMint",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "withdrawReserveCollateralSupply",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "withdrawReserveLiquiditySupply",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "withdrawReserveLiquidityFeeReceiver",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userSourceLiquidity",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userDestinationCollateral",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userDestinationLiquidity",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "collateralTokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "repayLiquidityTokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "withdrawLiquidityTokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "instructionSysvarAccount",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "liquidityAmount",
+          "type": "u64"
+        },
+        {
+          "name": "minAcceptableReceivedLiquidityAmount",
+          "type": "u64"
+        },
+        {
+          "name": "maxAllowedLtvOverridePercent",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "liquidateObligationAndRedeemReserveCollateralV2",
+      "accounts": [
+        {
+          "name": "liquidationAccounts",
+          "accounts": [
+            {
+              "name": "liquidator",
+              "isMut": false,
+              "isSigner": true
+            },
+            {
+              "name": "obligation",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "lendingMarket",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "lendingMarketAuthority",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "repayReserve",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "repayReserveLiquidityMint",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "repayReserveLiquiditySupply",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "withdrawReserve",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "withdrawReserveLiquidityMint",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "withdrawReserveCollateralMint",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "withdrawReserveCollateralSupply",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "withdrawReserveLiquiditySupply",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "withdrawReserveLiquidityFeeReceiver",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "userSourceLiquidity",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "userDestinationCollateral",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "userDestinationLiquidity",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "collateralTokenProgram",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "repayLiquidityTokenProgram",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "withdrawLiquidityTokenProgram",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "instructionSysvarAccount",
+              "isMut": false,
+              "isSigner": false
+            }
+          ]
+        },
+        {
+          "name": "collateralFarmsAccounts",
+          "accounts": [
+            {
+              "name": "obligationFarmUserState",
+              "isMut": true,
+              "isSigner": false,
+              "isOptional": true
+            },
+            {
+              "name": "reserveFarmState",
+              "isMut": true,
+              "isSigner": false,
+              "isOptional": true
+            }
+          ]
+        },
+        {
+          "name": "debtFarmsAccounts",
+          "accounts": [
+            {
+              "name": "obligationFarmUserState",
+              "isMut": true,
+              "isSigner": false,
+              "isOptional": true
+            },
+            {
+              "name": "reserveFarmState",
+              "isMut": true,
+              "isSigner": false,
+              "isOptional": true
+            }
+          ]
+        },
+        {
+          "name": "farmsProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "liquidityAmount",
+          "type": "u64"
+        },
+        {
+          "name": "minAcceptableReceivedLiquidityAmount",
+          "type": "u64"
+        },
+        {
+          "name": "maxAllowedLtvOverridePercent",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "flashRepayReserveLiquidity",
+      "accounts": [
+        {
+          "name": "userTransferAuthority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "lendingMarketAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarket",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "reserve",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "reserveLiquidityMint",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "reserveDestinationLiquidity",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userSourceLiquidity",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "reserveLiquidityFeeReceiver",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "referrerTokenState",
+          "isMut": true,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "name": "referrerAccount",
+          "isMut": true,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "name": "sysvarInfo",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "liquidityAmount",
+          "type": "u64"
+        },
+        {
+          "name": "borrowInstructionIndex",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "flashBorrowReserveLiquidity",
+      "accounts": [
+        {
+          "name": "userTransferAuthority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "lendingMarketAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarket",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "reserve",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "reserveLiquidityMint",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "reserveSourceLiquidity",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userDestinationLiquidity",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "reserveLiquidityFeeReceiver",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "referrerTokenState",
+          "isMut": true,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "name": "referrerAccount",
+          "isMut": true,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "name": "sysvarInfo",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "liquidityAmount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "requestElevationGroup",
+      "accounts": [
+        {
+          "name": "owner",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "obligation",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarket",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "elevationGroup",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "initReferrerTokenState",
+      "accounts": [
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "lendingMarket",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "reserve",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "referrer",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "referrerTokenState",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "initUserMetadata",
+      "accounts": [
+        {
+          "name": "owner",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "feePayer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "userMetadata",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "referrerUserMetadata",
+          "isMut": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "userLookupTable",
+          "type": "publicKey"
+        }
+      ]
+    },
+    {
+      "name": "withdrawReferrerFees",
+      "accounts": [
+        {
+          "name": "referrer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "referrerTokenState",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "reserve",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "reserveLiquidityMint",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "reserveSupplyLiquidity",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "referrerTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarket",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarketAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "initReferrerStateAndShortUrl",
+      "accounts": [
+        {
+          "name": "referrer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "referrerState",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "referrerShortUrl",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "referrerUserMetadata",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "shortUrl",
+          "type": "string"
+        }
+      ]
+    },
+    {
+      "name": "deleteReferrerStateAndShortUrl",
+      "accounts": [
+        {
+          "name": "referrer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "referrerState",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "shortUrl",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "setObligationOrder",
+      "accounts": [
+        {
+          "name": "owner",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "obligation",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarket",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "index",
+          "type": "u8"
+        },
+        {
+          "name": "order",
+          "type": {
+            "defined": "ObligationOrder"
+          }
+        }
+      ]
+    },
+    {
+      "name": "setBorrowOrder",
+      "accounts": [
+        {
+          "name": "owner",
+          "isMut": false,
+          "isSigner": true,
+          "docs": [
+            "The [Self::obligation]'s owner."
+          ]
+        },
+        {
+          "name": "obligation",
+          "isMut": true,
+          "isSigner": false,
+          "docs": [
+            "The obligation to set the [BorrowOrder] on."
+          ]
+        },
+        {
+          "name": "lendingMarket",
+          "isMut": false,
+          "isSigner": false,
+          "docs": [
+            "The [Self::obligation]'s market - needed only to validate the borrow orders' feature flag."
+          ]
+        },
+        {
+          "name": "filledDebtDestination",
+          "isMut": false,
+          "isSigner": false,
+          "docs": [
+            "The [BorrowOrder::filled_debt_destination] to set on order creation. Not editable on order",
+            "updates.",
+            "Ignored when cancelling the order."
+          ]
+        },
+        {
+          "name": "debtLiquidityMint",
+          "isMut": false,
+          "isSigner": false,
+          "docs": [
+            "The [BorrowOrder::debt_liquidity_mint] to set on order creation. Not editable on order",
+            "updates.",
+            "Ignored when cancelling the order."
+          ]
+        },
+        {
+          "name": "eventAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "program",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "orderConfig",
+          "type": {
+            "defined": "BorrowOrderConfigArgs"
+          }
+        },
+        {
+          "name": "minExpectedCurrentRemainingDebtAmount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "fillBorrowOrder",
+      "accounts": [
+        {
+          "name": "borrowAccounts",
+          "accounts": [
+            {
+              "name": "payer",
+              "isMut": false,
+              "isSigner": true
+            },
+            {
+              "name": "obligation",
+              "isMut": true,
+              "isSigner": false,
+              "docs": [
+                "The obligation with a [BorrowOrder]."
+              ]
+            },
+            {
+              "name": "lendingMarket",
+              "isMut": false,
+              "isSigner": false,
+              "docs": [
+                "The [Self::obligation]'s market - needed for borrowing-related configuration."
+              ]
+            },
+            {
+              "name": "lendingMarketAuthority",
+              "isMut": false,
+              "isSigner": false,
+              "docs": [
+                "The [Self::lending_market]'s authority, needed to transfer the newly-borrowed funds out of",
+                "the [Self::reserve_source_liquidity]."
+              ]
+            },
+            {
+              "name": "borrowReserve",
+              "isMut": true,
+              "isSigner": false,
+              "docs": [
+                "The reserve to borrow from.",
+                "",
+                "Its mint must match the asset requested by the [BorrowOrder::debt_liquidity_mint]."
+              ]
+            },
+            {
+              "name": "borrowReserveLiquidityMint",
+              "isMut": false,
+              "isSigner": false,
+              "docs": [
+                "The mint of [Self::borrow_reserve] - needed to execute the transfer."
+              ]
+            },
+            {
+              "name": "reserveSourceLiquidity",
+              "isMut": true,
+              "isSigner": false,
+              "docs": [
+                "The vault of [Self::borrow_reserve], from which the funds are transferred."
+              ]
+            },
+            {
+              "name": "borrowReserveLiquidityFeeReceiver",
+              "isMut": true,
+              "isSigner": false,
+              "docs": [
+                "The fee vault of [Self::borrow_reserve], to which the fees are transferred."
+              ]
+            },
+            {
+              "name": "userDestinationLiquidity",
+              "isMut": true,
+              "isSigner": false,
+              "docs": [
+                "The destination token account that should receive the newly borrowed funds.",
+                "",
+                "It must match [BorrowOrder::filled_debt_destination], owner and mint.",
+                "",
+                "**Warning:** An altered destination account will prevent an order from being filled."
+              ]
+            },
+            {
+              "name": "referrerTokenState",
+              "isMut": true,
+              "isSigner": false,
+              "isOptional": true,
+              "docs": [
+                "The referrer's account, for accumulating fees - needed if the [Obligation::has_referrer]."
+              ]
+            },
+            {
+              "name": "tokenProgram",
+              "isMut": false,
+              "isSigner": false,
+              "docs": [
+                "The token program of [Self::borrow_reserve] - needed to execute the transfer."
+              ]
+            }
+          ]
+        },
+        {
+          "name": "farmsAccounts",
+          "accounts": [
+            {
+              "name": "obligationFarmUserState",
+              "isMut": true,
+              "isSigner": false,
+              "isOptional": true
+            },
+            {
+              "name": "reserveFarmState",
+              "isMut": true,
+              "isSigner": false,
+              "isOptional": true
+            }
+          ]
+        },
+        {
+          "name": "farmsProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "eventAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "program",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "initGlobalConfig",
+      "accounts": [
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "globalConfig",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "programData",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "updateGlobalConfig",
+      "accounts": [
+        {
+          "name": "globalAdmin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "globalConfig",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "mode",
+          "type": {
+            "defined": "UpdateGlobalConfigMode"
+          }
+        },
+        {
+          "name": "value",
+          "type": "bytes"
+        }
+      ]
+    },
+    {
+      "name": "updateGlobalConfigAdmin",
+      "accounts": [
+        {
+          "name": "pendingAdmin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "globalConfig",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "idlMissingTypes",
+      "accounts": [
+        {
+          "name": "signer",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "globalConfig",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarket",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "reserve",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "reserveFarmKind",
+          "type": {
+            "defined": "ReserveFarmKind"
+          }
+        },
+        {
+          "name": "feeCalculation",
+          "type": {
+            "defined": "FeeCalculation"
+          }
+        },
+        {
+          "name": "reserveStatus",
+          "type": {
+            "defined": "ReserveStatus"
+          }
+        },
+        {
+          "name": "updateConfigMode",
+          "type": {
+            "defined": "UpdateConfigMode"
+          }
+        },
+        {
+          "name": "updateLendingMarketConfigValue",
+          "type": {
+            "defined": "UpdateLendingMarketConfigValue"
+          }
+        },
+        {
+          "name": "updateLendingMarketConfigMode",
+          "type": {
+            "defined": "UpdateLendingMarketMode"
+          }
+        }
+      ]
+    }
+  ],
+  "accounts": [
+    {
+      "name": "UserState",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "userId",
+            "type": "u64"
+          },
+          {
+            "name": "farmState",
+            "type": "publicKey"
+          },
+          {
+            "name": "owner",
+            "type": "publicKey"
+          },
+          {
+            "name": "isFarmDelegated",
+            "type": "u8"
+          },
+          {
+            "name": "padding0",
+            "type": {
+              "array": [
+                "u8",
+                7
+              ]
+            }
+          },
+          {
+            "name": "rewardsTallyScaled",
+            "type": {
+              "array": [
+                "u128",
+                10
+              ]
+            }
+          },
+          {
+            "name": "rewardsIssuedUnclaimed",
+            "type": {
+              "array": [
+                "u64",
+                10
+              ]
+            }
+          },
+          {
+            "name": "lastClaimTs",
+            "type": {
+              "array": [
+                "u64",
+                10
+              ]
+            }
+          },
+          {
+            "name": "activeStakeScaled",
+            "type": "u128"
+          },
+          {
+            "name": "pendingDepositStakeScaled",
+            "type": "u128"
+          },
+          {
+            "name": "pendingDepositStakeTs",
+            "type": "u64"
+          },
+          {
+            "name": "pendingWithdrawalUnstakeScaled",
+            "type": "u128"
+          },
+          {
+            "name": "pendingWithdrawalUnstakeTs",
+            "type": "u64"
+          },
+          {
+            "name": "bump",
+            "type": "u64"
+          },
+          {
+            "name": "delegatee",
+            "type": "publicKey"
+          },
+          {
+            "name": "lastStakeTs",
+            "type": "u64"
+          },
+          {
+            "name": "padding1",
+            "type": {
+              "array": [
+                "u64",
+                50
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "GlobalConfig",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "globalAdmin",
+            "docs": [
+              "Global admin of the program"
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "pendingAdmin",
+            "docs": [
+              "Pending admin must sign a specific transaction to become the global admin"
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "feeCollector",
+            "docs": [
+              "Fee collector is the only allowed owner of token accounts receiving protocol fees"
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "padding",
+            "docs": [
+              "Padding to make the struct size 1024 bytes"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                928
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "LendingMarket",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "version",
+            "docs": [
+              "Version of lending market"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "bumpSeed",
+            "docs": [
+              "Bump seed for derived authority address"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "lendingMarketOwner",
+            "docs": [
+              "Owner authority which can add new reserves"
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "lendingMarketOwnerCached",
+            "docs": [
+              "Temporary cache of the lending market owner, used in update_lending_market_owner"
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "quoteCurrency",
+            "docs": [
+              "Currency market prices are quoted in",
+              "e.g. \"USD\" null padded (`*b\"USD\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\"`) or a SPL token mint pubkey"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "referralFeeBps",
+            "docs": [
+              "Referral fee for the lending market, as bps out of the total protocol fee"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "emergencyMode",
+            "type": "u8"
+          },
+          {
+            "name": "autodeleverageEnabled",
+            "docs": [
+              "Whether the obligations on this market should be subject to auto-deleveraging after deposit",
+              "or borrow limit is crossed.",
+              "Besides this flag, the particular reserve's flag also needs to be enabled (logical `AND`).",
+              "**NOTE:** this also affects the individual \"target LTV\" deleveraging."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "borrowDisabled",
+            "type": "u8"
+          },
+          {
+            "name": "priceRefreshTriggerToMaxAgePct",
+            "docs": [
+              "Refresh price from oracle only if it's older than this percentage of the price max age.",
+              "e.g. if the max age is set to 100s and this is set to 80%, the price will be refreshed if it's older than 80s.",
+              "Price is always refreshed if this set to 0."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "liquidationMaxDebtCloseFactorPct",
+            "docs": [
+              "Percentage of the total borrowed value in an obligation available for liquidation"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "insolvencyRiskUnhealthyLtvPct",
+            "docs": [
+              "Minimum acceptable unhealthy LTV before max_debt_close_factor_pct becomes 100%"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "minFullLiquidationValueThreshold",
+            "docs": [
+              "Minimum liquidation value threshold triggering full liquidation for an obligation"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "maxLiquidatableDebtMarketValueAtOnce",
+            "docs": [
+              "Max allowed liquidation value in one ix call"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "reserved0",
+            "docs": [
+              "[DEPRECATED] Global maximum unhealthy borrow value allowed for any obligation"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                8
+              ]
+            }
+          },
+          {
+            "name": "globalAllowedBorrowValue",
+            "docs": [
+              "Global maximum allowed borrow value allowed for any obligation"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "riskCouncil",
+            "docs": [
+              "The address of the risk council, in charge of making parameter and risk decisions on behalf of the protocol"
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "reserved1",
+            "docs": [
+              "[DEPRECATED] Reward points multiplier per obligation type"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                8
+              ]
+            }
+          },
+          {
+            "name": "elevationGroups",
+            "docs": [
+              "Elevation groups are used to group together reserves that have the same risk parameters and can bump the ltv and liquidation threshold"
+            ],
+            "type": {
+              "array": [
+                {
+                  "defined": "ElevationGroup"
+                },
+                32
+              ]
+            }
+          },
+          {
+            "name": "elevationGroupPadding",
+            "type": {
+              "array": [
+                "u64",
+                90
+              ]
+            }
+          },
+          {
+            "name": "minNetValueInObligationSf",
+            "docs": [
+              "Min net value accepted to be found in a position after any lending action in an obligation (scaled by quote currency decimals)"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "minValueSkipLiquidationLtvChecks",
+            "docs": [
+              "Minimum value to enforce smallest ltv priority checks on the collateral reserves on liquidation"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "name",
+            "docs": [
+              "Market name, zero-padded."
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "minValueSkipLiquidationBfChecks",
+            "docs": [
+              "Minimum value to enforce highest borrow factor priority checks on the debt reserves on liquidation"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "individualAutodeleverageMarginCallPeriodSecs",
+            "docs": [
+              "Time (in seconds) that must pass before liquidation is allowed on an obligation that has",
+              "been individually marked for auto-deleveraging (by the risk council)."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "minInitialDepositAmount",
+            "docs": [
+              "Minimum amount of deposit at creation of a reserve to prevent artificial inflation",
+              "Note: this amount cannot be recovered, the ctoken associated are never minted"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "obligationOrderExecutionEnabled",
+            "docs": [
+              "Whether the obligation orders should be evaluated during liquidations."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "immutable",
+            "docs": [
+              "Whether the lending market is set as immutable."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "obligationOrderCreationEnabled",
+            "docs": [
+              "Whether new obligation orders can be created.",
+              "Note: updating or cancelling existing orders is *not* affected by this flag."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "priceTriggeredLiquidationDisabled",
+            "docs": [
+              "Whether the liquidation operations that are triggered by price changes should be disabled.",
+              "This includes regular liquidation (i.e. LTV exceeding the unhealthy threshold) and some",
+              "obligation orders' execution.",
+              "",
+              "*Caution:* this flag is *disabling* the liquidations when `1` - contrary to all the other",
+              "liquidation-driving flags (see e.g. [Self::autodeleverage_enabled])."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "matureReserveDebtLiquidationEnabled",
+            "docs": [
+              "Whether the debts that reached their reserve's [ReserveConfig::debt_maturity_timestamp] can",
+              "be liquidated."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "obligationBorrowDebtTermLiquidationEnabled",
+            "docs": [
+              "Whether the [Obligation::borrows] that reached their [ReserveConfig::debt_term_seconds] can",
+              "be liquidated."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "borrowOrderCreationEnabled",
+            "docs": [
+              "Whether new borrow orders can be created.",
+              "Note: updating or cancelling existing orders is *not* affected by this flag."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "borrowOrderExecutionEnabled",
+            "docs": [
+              "Whether the existing borrow orders can be filled."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "proposerAuthority",
+            "docs": [
+              "Authority that can propose creating of new reserves but cannot enable them."
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "padding1",
+            "type": {
+              "array": [
+                "u64",
+                165
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Obligation",
+      "docs": [
+        "Lending market obligation state"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "tag",
+            "docs": [
+              "Version of the struct"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "lastUpdate",
+            "docs": [
+              "Last update to collateral, liquidity, or their market values"
+            ],
+            "type": {
+              "defined": "LastUpdate"
+            }
+          },
+          {
+            "name": "lendingMarket",
+            "docs": [
+              "Lending market address"
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "owner",
+            "docs": [
+              "Owner authority which can borrow liquidity"
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "deposits",
+            "docs": [
+              "Deposited collateral for the obligation, unique by deposit reserve address"
+            ],
+            "type": {
+              "array": [
+                {
+                  "defined": "ObligationCollateral"
+                },
+                8
+              ]
+            }
+          },
+          {
+            "name": "lowestReserveDepositLiquidationLtv",
+            "docs": [
+              "Worst LTV for the collaterals backing the loan, represented as a percentage"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "depositedValueSf",
+            "docs": [
+              "Market value of deposits (scaled fraction)"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "borrows",
+            "docs": [
+              "Borrowed liquidity for the obligation, unique by borrow reserve address"
+            ],
+            "type": {
+              "array": [
+                {
+                  "defined": "ObligationLiquidity"
+                },
+                5
+              ]
+            }
+          },
+          {
+            "name": "borrowFactorAdjustedDebtValueSf",
+            "docs": [
+              "Risk adjusted market value of borrows/debt (sum of price * borrowed_amount * borrow_factor) (scaled fraction)"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "borrowedAssetsMarketValueSf",
+            "docs": [
+              "Market value of borrows - used for max_liquidatable_borrowed_amount (scaled fraction)"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "allowedBorrowValueSf",
+            "docs": [
+              "The maximum borrow value at the weighted average loan to value ratio (scaled fraction)"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "unhealthyBorrowValueSf",
+            "docs": [
+              "The dangerous borrow value at the weighted average liquidation threshold (scaled fraction)"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "paddingDeprecatedAssetTiers",
+            "docs": [
+              "The asset tier of the deposits"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                13
+              ]
+            }
+          },
+          {
+            "name": "elevationGroup",
+            "docs": [
+              "The elevation group id the obligation opted into."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "numOfObsoleteDepositReserves",
+            "docs": [
+              "The number of obsolete reserves the obligation has a deposit in"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "hasDebt",
+            "docs": [
+              "Marked = 1 if borrows array is not empty, 0 = borrows empty"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "referrer",
+            "docs": [
+              "Wallet address of the referrer"
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "borrowingDisabled",
+            "docs": [
+              "Marked = 1 if borrowing disabled, 0 = borrowing enabled"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "autodeleverageTargetLtvPct",
+            "docs": [
+              "A target LTV set by the risk council when marking this obligation for deleveraging.",
+              "Only effective when `deleveraging_margin_call_started_slot != 0`."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "lowestReserveDepositMaxLtvPct",
+            "docs": [
+              "The lowest max LTV found amongst the collateral deposits"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "numOfObsoleteBorrowReserves",
+            "docs": [
+              "The number of obsolete reserves the obligation has a borrow in"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "reserved",
+            "type": {
+              "array": [
+                "u8",
+                4
+              ]
+            }
+          },
+          {
+            "name": "highestBorrowFactorPct",
+            "type": "u64"
+          },
+          {
+            "name": "autodeleverageMarginCallStartedTimestamp",
+            "docs": [
+              "A timestamp at which the risk council most-recently marked this obligation for deleveraging.",
+              "Zero if not currently subject to deleveraging."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "obligationOrders",
+            "docs": [
+              "Owner-defined, permissionlessly-executed repay orders.",
+              "Typical use-cases would be a stop-loss and a take-profit (possibly co-existing)."
+            ],
+            "type": {
+              "array": [
+                {
+                  "defined": "ObligationOrder"
+                },
+                2
+              ]
+            }
+          },
+          {
+            "name": "borrowOrder",
+            "docs": [
+              "Owner-defined, permissionlessly-executed borrow order applicable to this obligation.",
+              "Non-zeroed only on a newly-initialized fixed-rate, fixed-term obligation."
+            ],
+            "type": {
+              "defined": "BorrowOrder"
+            }
+          },
+          {
+            "name": "padding3",
+            "type": {
+              "array": [
+                "u64",
+                73
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ReferrerState",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "shortUrl",
+            "type": "publicKey"
+          },
+          {
+            "name": "owner",
+            "type": "publicKey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ReferrerTokenState",
+      "docs": [
+        "Referrer account -> each owner can have multiple accounts for specific reserves"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "referrer",
+            "docs": [
+              "Pubkey of the referrer/owner"
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "mint",
+            "docs": [
+              "Token mint for the account"
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "amountUnclaimedSf",
+            "docs": [
+              "Amount that has been accumulated and not claimed yet -> available to claim (scaled fraction)"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "amountCumulativeSf",
+            "docs": [
+              "Amount that has been accumulated in total -> both already claimed and unclaimed (scaled fraction)"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "bump",
+            "docs": [
+              "Referrer token state bump, used for address validation"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u64",
+                31
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ShortUrl",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "referrer",
+            "type": "publicKey"
+          },
+          {
+            "name": "shortUrl",
+            "type": "string"
+          }
+        ]
+      }
+    },
+    {
+      "name": "UserMetadata",
+      "docs": [
+        "Referrer account -> each owner can have multiple accounts for specific reserves"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "referrer",
+            "docs": [
+              "Pubkey of the referrer/owner - pubkey::default if no referrer"
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "bump",
+            "docs": [
+              "Bump used for validation of account address"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "userLookupTable",
+            "docs": [
+              "User lookup table - used to store all user accounts - atas for each reserve mint, each obligation PDA, UserMetadata itself and all referrer_token_states if there is a referrer"
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "owner",
+            "docs": [
+              "User metadata account owner"
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "padding1",
+            "type": {
+              "array": [
+                "u64",
+                51
+              ]
+            }
+          },
+          {
+            "name": "padding2",
+            "type": {
+              "array": [
+                "u64",
+                64
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Reserve",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "version",
+            "docs": [
+              "Version of the reserve"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "lastUpdate",
+            "docs": [
+              "Last slot when supply and rates updated"
+            ],
+            "type": {
+              "defined": "LastUpdate"
+            }
+          },
+          {
+            "name": "lendingMarket",
+            "docs": [
+              "Lending market address"
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "farmCollateral",
+            "type": "publicKey"
+          },
+          {
+            "name": "farmDebt",
+            "type": "publicKey"
+          },
+          {
+            "name": "liquidity",
+            "docs": [
+              "Reserve liquidity"
+            ],
+            "type": {
+              "defined": "ReserveLiquidity"
+            }
+          },
+          {
+            "name": "reserveLiquidityPadding",
+            "type": {
+              "array": [
+                "u64",
+                150
+              ]
+            }
+          },
+          {
+            "name": "collateral",
+            "docs": [
+              "Reserve collateral"
+            ],
+            "type": {
+              "defined": "ReserveCollateral"
+            }
+          },
+          {
+            "name": "reserveCollateralPadding",
+            "type": {
+              "array": [
+                "u64",
+                150
+              ]
+            }
+          },
+          {
+            "name": "config",
+            "docs": [
+              "Reserve configuration values"
+            ],
+            "type": {
+              "defined": "ReserveConfig"
+            }
+          },
+          {
+            "name": "configPadding",
+            "type": {
+              "array": [
+                "u64",
+                114
+              ]
+            }
+          },
+          {
+            "name": "borrowedAmountOutsideElevationGroup",
+            "type": "u64"
+          },
+          {
+            "name": "borrowedAmountsAgainstThisReserveInElevationGroups",
+            "docs": [
+              "Amount of token borrowed in lamport of debt asset in the given",
+              "elevation group when this reserve is part of the collaterals."
+            ],
+            "type": {
+              "array": [
+                "u64",
+                32
+              ]
+            }
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u64",
+                207
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "types": [
+    {
+      "name": "BorrowOrderConfigArgs",
+      "docs": [
+        "A subset of [BorrowOrderConfig] excluding the accounts passed via [SetBorrowOrder]."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "remainingDebtAmount",
+            "type": "u64"
+          },
+          {
+            "name": "maxBorrowRateBps",
+            "type": "u32"
+          },
+          {
+            "name": "minDebtTermSeconds",
+            "type": "u64"
+          },
+          {
+            "name": "fillableUntilTimestamp",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "UpdateConfigMode",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "UpdateLoanToValuePct"
+          },
+          {
+            "name": "UpdateMaxLiquidationBonusBps"
+          },
+          {
+            "name": "UpdateLiquidationThresholdPct"
+          },
+          {
+            "name": "UpdateProtocolLiquidationFee"
+          },
+          {
+            "name": "UpdateProtocolTakeRate"
+          },
+          {
+            "name": "UpdateFeesOriginationFee"
+          },
+          {
+            "name": "UpdateFeesFlashLoanFee"
+          },
+          {
+            "name": "DeprecatedUpdateFeesReferralFeeBps"
+          },
+          {
+            "name": "UpdateDepositLimit"
+          },
+          {
+            "name": "UpdateBorrowLimit"
+          },
+          {
+            "name": "UpdateTokenInfoLowerHeuristic"
+          },
+          {
+            "name": "UpdateTokenInfoUpperHeuristic"
+          },
+          {
+            "name": "UpdateTokenInfoExpHeuristic"
+          },
+          {
+            "name": "UpdateTokenInfoTwapDivergence"
+          },
+          {
+            "name": "UpdateTokenInfoScopeTwap"
+          },
+          {
+            "name": "UpdateTokenInfoScopeChain"
+          },
+          {
+            "name": "UpdateTokenInfoName"
+          },
+          {
+            "name": "UpdateTokenInfoPriceMaxAge"
+          },
+          {
+            "name": "UpdateTokenInfoTwapMaxAge"
+          },
+          {
+            "name": "UpdateScopePriceFeed"
+          },
+          {
+            "name": "UpdatePythPrice"
+          },
+          {
+            "name": "UpdateSwitchboardFeed"
+          },
+          {
+            "name": "UpdateSwitchboardTwapFeed"
+          },
+          {
+            "name": "UpdateBorrowRateCurve"
+          },
+          {
+            "name": "UpdateEntireReserveConfig"
+          },
+          {
+            "name": "UpdateDebtWithdrawalCap"
+          },
+          {
+            "name": "UpdateDepositWithdrawalCap"
+          },
+          {
+            "name": "DeprecatedUpdateDebtWithdrawalCapCurrentTotal"
+          },
+          {
+            "name": "DeprecatedUpdateDepositWithdrawalCapCurrentTotal"
+          },
+          {
+            "name": "UpdateBadDebtLiquidationBonusBps"
+          },
+          {
+            "name": "UpdateMinLiquidationBonusBps"
+          },
+          {
+            "name": "UpdateDeleveragingMarginCallPeriod"
+          },
+          {
+            "name": "UpdateBorrowFactor"
+          },
+          {
+            "name": "DeprecatedUpdateAssetTier"
+          },
+          {
+            "name": "UpdateElevationGroup"
+          },
+          {
+            "name": "UpdateDeleveragingThresholdDecreaseBpsPerDay"
+          },
+          {
+            "name": "DeprecatedUpdateMultiplierSideBoost"
+          },
+          {
+            "name": "DeprecatedUpdateMultiplierTagBoost"
+          },
+          {
+            "name": "UpdateReserveStatus"
+          },
+          {
+            "name": "UpdateFarmCollateral"
+          },
+          {
+            "name": "UpdateFarmDebt"
+          },
+          {
+            "name": "UpdateDisableUsageAsCollateralOutsideEmode"
+          },
+          {
+            "name": "UpdateBlockBorrowingAboveUtilizationPct"
+          },
+          {
+            "name": "UpdateBlockPriceUsage"
+          },
+          {
+            "name": "UpdateBorrowLimitOutsideElevationGroup"
+          },
+          {
+            "name": "UpdateBorrowLimitsInElevationGroupAgainstThisReserve"
+          },
+          {
+            "name": "UpdateHostFixedInterestRateBps"
+          },
+          {
+            "name": "UpdateAutodeleverageEnabled"
+          },
+          {
+            "name": "UpdateDeleveragingBonusIncreaseBpsPerDay"
+          },
+          {
+            "name": "UpdateProtocolOrderExecutionFee"
+          },
+          {
+            "name": "UpdateProposerAuthorityLock"
+          },
+          {
+            "name": "UpdateMinDeleveragingBonusBps"
+          },
+          {
+            "name": "UpdateBlockCTokenUsage"
+          },
+          {
+            "name": "UpdateDebtMaturityTimestamp"
+          },
+          {
+            "name": "UpdateDebtTermSeconds"
+          }
+        ]
+      }
+    },
+    {
+      "name": "UpdateLendingMarketConfigValue",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Bool",
+            "fields": [
+              "bool"
+            ]
+          },
+          {
+            "name": "U8",
+            "fields": [
+              "u8"
+            ]
+          },
+          {
+            "name": "U8Array",
+            "fields": [
+              {
+                "array": [
+                  "u8",
+                  8
+                ]
+              }
+            ]
+          },
+          {
+            "name": "U16",
+            "fields": [
+              "u16"
+            ]
+          },
+          {
+            "name": "U64",
+            "fields": [
+              "u64"
+            ]
+          },
+          {
+            "name": "U128",
+            "fields": [
+              "u128"
+            ]
+          },
+          {
+            "name": "Pubkey",
+            "fields": [
+              "publicKey"
+            ]
+          },
+          {
+            "name": "ElevationGroup",
+            "fields": [
+              {
+                "defined": "ElevationGroup"
+              }
+            ]
+          },
+          {
+            "name": "Name",
+            "fields": [
+              {
+                "array": [
+                  "u8",
+                  32
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "UpdateLendingMarketMode",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "UpdateOwner"
+          },
+          {
+            "name": "UpdateEmergencyMode"
+          },
+          {
+            "name": "UpdateLiquidationCloseFactor"
+          },
+          {
+            "name": "UpdateLiquidationMaxValue"
+          },
+          {
+            "name": "DeprecatedUpdateGlobalUnhealthyBorrow"
+          },
+          {
+            "name": "UpdateGlobalAllowedBorrow"
+          },
+          {
+            "name": "UpdateRiskCouncil"
+          },
+          {
+            "name": "UpdateMinFullLiquidationThreshold"
+          },
+          {
+            "name": "UpdateInsolvencyRiskLtv"
+          },
+          {
+            "name": "UpdateElevationGroup"
+          },
+          {
+            "name": "UpdateReferralFeeBps"
+          },
+          {
+            "name": "DeprecatedUpdateMultiplierPoints"
+          },
+          {
+            "name": "UpdatePriceRefreshTriggerToMaxAgePct"
+          },
+          {
+            "name": "UpdateAutodeleverageEnabled"
+          },
+          {
+            "name": "UpdateBorrowingDisabled"
+          },
+          {
+            "name": "UpdateMinNetValueObligationPostAction"
+          },
+          {
+            "name": "UpdateMinValueLtvSkipPriorityLiqCheck"
+          },
+          {
+            "name": "UpdateMinValueBfSkipPriorityLiqCheck"
+          },
+          {
+            "name": "UpdatePaddingFields"
+          },
+          {
+            "name": "UpdateName"
+          },
+          {
+            "name": "UpdateIndividualAutodeleverageMarginCallPeriodSecs"
+          },
+          {
+            "name": "UpdateInitialDepositAmount"
+          },
+          {
+            "name": "UpdateObligationOrderExecutionEnabled"
+          },
+          {
+            "name": "UpdateImmutableFlag"
+          },
+          {
+            "name": "UpdateObligationOrderCreationEnabled"
+          },
+          {
+            "name": "UpdateProposerAuthority"
+          },
+          {
+            "name": "UpdatePriceTriggeredLiquidationDisabled"
+          },
+          {
+            "name": "UpdateMatureReserveDebtLiquidationEnabled"
+          },
+          {
+            "name": "UpdateObligationBorrowDebtTermLiquidationEnabled"
+          },
+          {
+            "name": "UpdateBorrowOrderCreationEnabled"
+          },
+          {
+            "name": "UpdateBorrowOrderExecutionEnabled"
+          }
+        ]
+      }
+    },
+    {
+      "name": "UpdateGlobalConfigMode",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "PendingAdmin"
+          },
+          {
+            "name": "FeeCollector"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LastUpdate",
+      "docs": [
+        "Last update state"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "slot",
+            "docs": [
+              "Last slot when updated"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "stale",
+            "docs": [
+              "True when marked stale, false when slot updated"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "priceStatus",
+            "docs": [
+              "Status of the prices used to calculate the last update"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "placeholder",
+            "type": {
+              "array": [
+                "u8",
+                6
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ElevationGroup",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "maxLiquidationBonusBps",
+            "type": "u16"
+          },
+          {
+            "name": "id",
+            "type": "u8"
+          },
+          {
+            "name": "ltvPct",
+            "type": "u8"
+          },
+          {
+            "name": "liquidationThresholdPct",
+            "type": "u8"
+          },
+          {
+            "name": "allowNewLoans",
+            "type": "u8"
+          },
+          {
+            "name": "maxReservesAsCollateral",
+            "type": "u8"
+          },
+          {
+            "name": "padding0",
+            "type": "u8"
+          },
+          {
+            "name": "debtReserve",
+            "docs": [
+              "Mandatory debt reserve for this elevation group"
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "padding1",
+            "type": {
+              "array": [
+                "u64",
+                4
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "BorrowOrder",
+      "docs": [
+        "A borrow order.",
+        "",
+        "When the [Obligation::borrow_order] is populated (i.e. non-zeroed) on an Obligation, then the",
+        "permissionless \"fill\" operations may borrow liquidity to the owner according to this",
+        "specification."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "debtLiquidityMint",
+            "docs": [
+              "The asset to be borrowed.",
+              "The reserves used for [Obligation::borrows] *must* all provide exactly this asset."
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "remainingDebtAmount",
+            "docs": [
+              "The amount of debt that still needs to be filled, in lamports."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "filledDebtDestination",
+            "docs": [
+              "The token account owned by the [Obligation::owner] and holding [Self::debt_liquidity_mint],",
+              "where the filled funds should be transferred to."
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "minDebtTermSeconds",
+            "docs": [
+              "The minimum allowed debt term that the obligation owner agrees to.",
+              "The reserves used to fill this order *cannot* define their debt term *lower* than this.",
+              "",
+              "If zeroed, then only indefinite-term reserves may be used."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "fillableUntilTimestamp",
+            "docs": [
+              "The time until which the borrow order can still be filled."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "placedAtTimestamp",
+            "docs": [
+              "The time at which this order was placed.",
+              "Currently, this is only a piece of metadata."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "lastUpdatedAtTimestamp",
+            "docs": [
+              "The time at which this order was most-recently updated (including: created).",
+              "Currently, this is only a piece of metadata."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "requestedDebtAmount",
+            "docs": [
+              "The amount of debt that was originally requested when this order was most-recently updated.",
+              "In other words: this field holds a value of [Self::remaining_debt_amount] captured at",
+              "[Self::last_updated_at_timestamp].",
+              "Currently, this is only a piece of metadata."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "maxBorrowRateBps",
+            "docs": [
+              "The maximum borrow rate that the obligation owner agrees to.",
+              "The reserves used for [Obligation::borrows] *cannot* define their maximum borrow rate",
+              "*higher* than this."
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "padding1",
+            "docs": [
+              "Alignment padding."
+            ],
+            "type": {
+              "array": [
+                "u8",
+                4
+              ]
+            }
+          },
+          {
+            "name": "endPadding",
+            "docs": [
+              "End padding."
+            ],
+            "type": {
+              "array": [
+                "u64",
+                5
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "InitObligationArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "tag",
+            "type": "u8"
+          },
+          {
+            "name": "id",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ObligationCollateral",
+      "docs": [
+        "Obligation collateral state"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "depositReserve",
+            "docs": [
+              "Reserve collateral is deposited to"
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "depositedAmount",
+            "docs": [
+              "Amount of collateral deposited"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "marketValueSf",
+            "docs": [
+              "Collateral market value in quote currency (scaled fraction)"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "borrowedAmountAgainstThisCollateralInElevationGroup",
+            "docs": [
+              "Debt amount (lamport) taken against this collateral.",
+              "(only meaningful if this obligation is part of an elevation group, otherwise 0)",
+              "This is only indicative of the debt computed on the last refresh obligation.",
+              "If the obligation have multiple collateral this value is the same for all of them."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u64",
+                9
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ObligationLiquidity",
+      "docs": [
+        "Obligation liquidity state"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "borrowReserve",
+            "docs": [
+              "Reserve liquidity is borrowed from"
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "cumulativeBorrowRateBsf",
+            "docs": [
+              "Borrow rate used for calculating interest (big scaled fraction)"
+            ],
+            "type": {
+              "defined": "BigFractionBytes"
+            }
+          },
+          {
+            "name": "firstBorrowedAtTimestamp",
+            "docs": [
+              "The timestamp at which this debt was taken.",
+              "More specifically: when the *first* borrow operation from this reserve happened.",
+              "This means that:",
+              "- adding debt of the same reserve does *not* change this timestamp,",
+              "- repaying the entire debt of this reserve *does* reset this timestamp.",
+              "",
+              "Note: this field is *not* only metadata: it is used in the logic, e.g. for enforcing the",
+              "fixed-term borrows (i.e. those induced by [ReserveConfig::debt_term_seconds])."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "borrowedAmountSf",
+            "docs": [
+              "Amount of liquidity borrowed plus interest (scaled fraction)"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "marketValueSf",
+            "docs": [
+              "Liquidity market value in quote currency (scaled fraction)"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "borrowFactorAdjustedMarketValueSf",
+            "docs": [
+              "Risk adjusted liquidity market value in quote currency - DEBUG ONLY - use market_value instead"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "borrowedAmountOutsideElevationGroups",
+            "docs": [
+              "Amount of liquidity borrowed outside of an elevation group"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "padding2",
+            "type": {
+              "array": [
+                "u64",
+                7
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ObligationOrder",
+      "docs": [
+        "A single obligation order.",
+        "See [Obligation::obligation_orders]."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "conditionThresholdSf",
+            "docs": [
+              "A threshold value used by the condition (scaled [Fraction]).",
+              "The exact meaning depends on the specific [Self::condition_type].",
+              "",
+              "Examples:",
+              "- when `condition_type == 2 (UserLtvBelow)`:",
+              "then a value of `0.455` here means that the order is active only when the obligation's",
+              "user LTV is less than `0.455` (i.e. < 45.5%).",
+              "- when `condition_type == 3 (DebtCollPriceRatioAbove)`:",
+              "assuming the obligation uses BTC collateral for SOL debt, then a value of `491.3` here",
+              "means that the order is active only when the BTC-SOL price is greater than `491.3` (i.e.",
+              "> 491.3 SOL per BTC)."
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "opportunityParameterSf",
+            "docs": [
+              "A configuration parameter used by the opportunity (scaled [Fraction]).",
+              "The exact meaning depends on the specific [Self::opportunity_type].",
+              "",
+              "Examples:",
+              "- when `opportunity_type == 0 (DeleverageSingleDebtAmount)`:",
+              "Assuming the obligation uses BTC collateral for SOL debt, then a value of `1_234_000_000`",
+              "here means that a liquidator may repay up to 1234000000 lamports (i.e. 1.234 SOL) on this",
+              "obligation.",
+              "Note: the special value of [Fraction::MAX] is *not* allowed in this case.",
+              "- when `opportunity_type == 1 (DeleverageAllDebtAmount)`:",
+              "The only allowed value in this case is [Fraction::MAX] (to emphasize that *all* debt",
+              "should be repaid)."
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "minExecutionBonusBps",
+            "docs": [
+              "A *minimum* additional fraction of collateral transferred to the liquidator, in bps.",
+              "",
+              "The minimum bonus is applied exactly when the [Self::condition_threshold_sf] is met, and",
+              "grows linearly towards the [Self::max_execution_bonus_bps].",
+              "",
+              "Example: a value of `50` here means 50bps == 0.5% bonus for an \"LTV > 65%\" order, when",
+              "executed precisely at the moment LTV exceeds 65%."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "maxExecutionBonusBps",
+            "docs": [
+              "A *maximum* additional fraction of collateral transferred to the liquidator, in bps.",
+              "",
+              "The maximum bonus is applied at the relevant \"extreme\" state of the obligation, i.e.:",
+              "- for a stop-loss condition, it is a point at which the obligation becomes liquidatable;",
+              "- for a take-profit condition, it is a point at which obligation has 0% LTV.",
+              "",
+              "In non-extreme states, the actual bonus value is interpolated linearly, starting from",
+              "[Self::min_execution_bonus_bps] (at the point specified by the order's condition).",
+              "",
+              "Example: a value of `300` here means 300bps == 3.0% bonus for a \"debt/coll price > 140\"",
+              "order, when executed at a higher price = 200, at which the obligation's LTV happens to",
+              "be equal to its liquidation LTV."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "conditionType",
+            "docs": [
+              "Serialized [ConditionType].",
+              "The entire order is void when this is zeroed (i.e. representing [ConditionType::Never]).",
+              "",
+              "Example: a value of `2` here denotes `UserLtvBelow` condition type. Of course, to",
+              "interpret this condition, we also need to take the [Self::condition_threshold_sf] into",
+              "account."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "opportunityType",
+            "docs": [
+              "Serialized [OpportunityType].",
+              "",
+              "Example: a value of `0` here denotes `DeleverageSingleDebtAmount` opportunity. Of course, to",
+              "interpret this opportunity, we also need to take the [Self::opportunity_parameter_sf] into",
+              "account."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "padding1",
+            "docs": [
+              "Alignment padding.",
+              "The fields above take up 2+2+1+1 bytes = 48 bits, which means we need 80 bits = 10 bytes to",
+              "align with `u128`s."
+            ],
+            "type": {
+              "array": [
+                "u8",
+                10
+              ]
+            }
+          },
+          {
+            "name": "padding2",
+            "docs": [
+              "End padding.",
+              "The total size of a single instance is 8*u128 = 128 bytes."
+            ],
+            "type": {
+              "array": [
+                "u128",
+                5
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "BigFractionBytes",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "value",
+            "type": {
+              "array": [
+                "u64",
+                4
+              ]
+            }
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u64",
+                2
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "FeeCalculation",
+      "docs": [
+        "Calculate fees exlusive or inclusive of an amount"
+      ],
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Exclusive"
+          },
+          {
+            "name": "Inclusive"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ReserveCollateral",
+      "docs": [
+        "Reserve collateral"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "mintPubkey",
+            "docs": [
+              "Reserve collateral mint address"
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "mintTotalSupply",
+            "docs": [
+              "Reserve collateral mint supply, used for exchange rate"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "supplyVault",
+            "docs": [
+              "Reserve collateral supply address"
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "padding1",
+            "type": {
+              "array": [
+                "u128",
+                32
+              ]
+            }
+          },
+          {
+            "name": "padding2",
+            "type": {
+              "array": [
+                "u128",
+                32
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ReserveConfig",
+      "docs": [
+        "Reserve configuration values"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "status",
+            "docs": [
+              "Status of the reserve Active/Obsolete/Hidden"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "paddingDeprecatedAssetTier",
+            "docs": [
+              "Asset tier -> 0 - regular (collateral & debt), 1 - isolated collateral, 2 - isolated debt"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "hostFixedInterestRateBps",
+            "docs": [
+              "Flat rate that goes to the host"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "minDeleveragingBonusBps",
+            "docs": [
+              "Starting bonus for deleveraging-related liquidations, in bps."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "blockCtokenUsage",
+            "docs": [
+              "Boolean flag to block minting/redeeming of ctokens",
+              "Blocks usage of ctokens (minting or withdrawing from obligation)",
+              "Effectively blocks deposit_reserve_liquidity and withdraw_obligation_collateral"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "reserved1",
+            "docs": [
+              "Past reserved space - feel free to reuse."
+            ],
+            "type": {
+              "array": [
+                "u8",
+                6
+              ]
+            }
+          },
+          {
+            "name": "protocolOrderExecutionFeePct",
+            "docs": [
+              "Cut of the order execution bonus that the protocol receives, as a percentage"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "protocolTakeRatePct",
+            "docs": [
+              "Protocol take rate is the amount borrowed interest protocol receives, as a percentage"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "protocolLiquidationFeePct",
+            "docs": [
+              "Cut of the liquidation bonus that the protocol receives, as a percentage"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "loanToValuePct",
+            "docs": [
+              "Target ratio of the value of borrows to deposits, as a percentage",
+              "0 if use as collateral is disabled"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "liquidationThresholdPct",
+            "docs": [
+              "Loan to value ratio at which an obligation can be liquidated, as percentage"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "minLiquidationBonusBps",
+            "docs": [
+              "Minimum bonus a liquidator receives when repaying part of an unhealthy obligation, as bps"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "maxLiquidationBonusBps",
+            "docs": [
+              "Maximum bonus a liquidator receives when repaying part of an unhealthy obligation, as bps"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "badDebtLiquidationBonusBps",
+            "docs": [
+              "Bad debt liquidation bonus for an undercollateralized obligation, as bps"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "deleveragingMarginCallPeriodSecs",
+            "docs": [
+              "Time in seconds that must pass before redemptions are enabled after the deposit limit is",
+              "crossed.",
+              "Only relevant when `autodeleverage_enabled == 1`, and must not be 0 in such case."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "deleveragingThresholdDecreaseBpsPerDay",
+            "docs": [
+              "The rate at which the deleveraging threshold decreases, in bps per day.",
+              "Only relevant when `autodeleverage_enabled == 1`, and must not be 0 in such case."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "fees",
+            "docs": [
+              "Program owner fees assessed, separate from gains due to interest accrual"
+            ],
+            "type": {
+              "defined": "ReserveFees"
+            }
+          },
+          {
+            "name": "borrowRateCurve",
+            "docs": [
+              "Borrow rate curve based on utilization"
+            ],
+            "type": {
+              "defined": "BorrowRateCurve"
+            }
+          },
+          {
+            "name": "borrowFactorPct",
+            "docs": [
+              "Borrow factor in percentage - used for risk adjustment"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "depositLimit",
+            "docs": [
+              "Maximum deposit limit of liquidity in native units, u64::MAX for inf"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "borrowLimit",
+            "docs": [
+              "Maximum amount borrowed, u64::MAX for inf, 0 to disable borrows (protected deposits)"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "tokenInfo",
+            "docs": [
+              "Token id from TokenInfos struct"
+            ],
+            "type": {
+              "defined": "TokenInfo"
+            }
+          },
+          {
+            "name": "depositWithdrawalCap",
+            "docs": [
+              "Deposit withdrawal caps - deposit & redeem"
+            ],
+            "type": {
+              "defined": "WithdrawalCaps"
+            }
+          },
+          {
+            "name": "debtWithdrawalCap",
+            "docs": [
+              "Debt withdrawal caps - borrow & repay"
+            ],
+            "type": {
+              "defined": "WithdrawalCaps"
+            }
+          },
+          {
+            "name": "elevationGroups",
+            "type": {
+              "array": [
+                "u8",
+                20
+              ]
+            }
+          },
+          {
+            "name": "disableUsageAsCollOutsideEmode",
+            "type": "u8"
+          },
+          {
+            "name": "utilizationLimitBlockBorrowingAbovePct",
+            "docs": [
+              "Utilization (in percentage) above which borrowing is blocked. 0 to disable."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "autodeleverageEnabled",
+            "docs": [
+              "Whether this reserve should be subject to auto-deleveraging after deposit or borrow limit is",
+              "crossed.",
+              "Besides this flag, the lending market's flag also needs to be enabled (logical `AND`).",
+              "**NOTE:** the manual \"target LTV\" deleveraging (enabled by the risk council for individual",
+              "obligations) is NOT affected by this flag."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "proposerAuthorityLocked",
+            "docs": [
+              "Boolean flag indicating whether the reserve is locked for the proposer authority.",
+              "",
+              "Once the proposer have finished preparing the reserve, it must be locked to prevent",
+              "further changes to the reserve configuration allowing review and voting on the proposal",
+              "without alteration during the voting period."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "borrowLimitOutsideElevationGroup",
+            "docs": [
+              "Maximum amount liquidity of this reserve borrowed outside all elevation groups",
+              "- u64::MAX for inf",
+              "- 0 to disable borrows outside elevation groups"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "borrowLimitAgainstThisCollateralInElevationGroup",
+            "docs": [
+              "Defines the maximum amount (in lamports of elevation group debt asset)",
+              "that can be borrowed when this reserve is used as collateral.",
+              "- u64::MAX for inf",
+              "- 0 to disable borrows in this elevation group (expected value for the debt asset)"
+            ],
+            "type": {
+              "array": [
+                "u64",
+                32
+              ]
+            }
+          },
+          {
+            "name": "deleveragingBonusIncreaseBpsPerDay",
+            "docs": [
+              "The rate at which the deleveraging-related liquidation bonus increases, in bps per day.",
+              "Only relevant when `autodeleverage_enabled == 1`, and must not be 0 in such case."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "debtMaturityTimestamp",
+            "docs": [
+              "The timestamp at which all [Obligation::borrows] using this reserve become liquidatable",
+              "(on the same terms as reserve-wide deleveraging).",
+              "Inactive when zeroed (i.e. debt never matures).",
+              "",
+              "Note: this feature is independent of [Self::debt_term_seconds] - the liquidation mechanism",
+              "is based directly on the timestamp defined here, on Reserve's level."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "debtTermSeconds",
+            "docs": [
+              "The duration after which any debt coming from this Reserve must be repaid.",
+              "Inactive when zeroed (i.e. funds can be borrowed indefinitely).",
+              "",
+              "Note: this feature is independent of [Self::debt_maturity_timestamp] - the liquidation",
+              "mechanism is based on the [ObligationLiquidity::first_borrowed_at_timestamp]."
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ReserveFarmKind",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Collateral"
+          },
+          {
+            "name": "Debt"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ReserveFees",
+      "docs": [
+        "Additional fee information on a reserve",
+        "",
+        "These exist separately from interest accrual fees, and are specifically for the program owner",
+        "and referral fee. The fees are paid out as a percentage of liquidity token amounts during",
+        "repayments and liquidations."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "originationFeeSf",
+            "docs": [
+              "Fee assessed on `BorrowObligationLiquidity`, as scaled fraction (60 bits fractional part)",
+              "Must be between `0` and `2^60`, such that `2^60 = 1`.  A few examples for",
+              "clarity:",
+              "1% = (1 << 60) / 100 = 11529215046068470",
+              "0.01% (1 basis point) = 115292150460685",
+              "0.00001% (Aave origination fee) = 115292150461"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "flashLoanFeeSf",
+            "docs": [
+              "Fee for flash loan, expressed as scaled fraction.",
+              "0.3% (Aave flash loan fee) = 0.003 * 2^60 = 3458764513820541"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "padding",
+            "docs": [
+              "Used for allignment"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                8
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ReserveLiquidity",
+      "docs": [
+        "Reserve liquidity"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "mintPubkey",
+            "docs": [
+              "Reserve liquidity mint address"
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "supplyVault",
+            "docs": [
+              "Reserve liquidity supply address"
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "feeVault",
+            "docs": [
+              "Reserve liquidity fee collection address"
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "availableAmount",
+            "docs": [
+              "Reserve liquidity available"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "borrowedAmountSf",
+            "docs": [
+              "Reserve liquidity borrowed (scaled fraction)"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "marketPriceSf",
+            "docs": [
+              "Reserve liquidity market price in quote currency (scaled fraction)"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "marketPriceLastUpdatedTs",
+            "docs": [
+              "Unix timestamp of the market price (from the oracle)"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "mintDecimals",
+            "docs": [
+              "Reserve liquidity mint decimals"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "depositLimitCrossedTimestamp",
+            "docs": [
+              "Timestamp when the last refresh reserve detected that the liquidity amount is above the deposit cap. When this threshold is crossed, then redemptions (auto-deleverage) are enabled.",
+              "If the threshold is not crossed, then the timestamp is set to 0"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "borrowLimitCrossedTimestamp",
+            "docs": [
+              "Timestamp when the last refresh reserve detected that the borrowed amount is above the borrow cap. When this threshold is crossed, then redemptions (auto-deleverage) are enabled.",
+              "If the threshold is not crossed, then the timestamp is set to 0"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "cumulativeBorrowRateBsf",
+            "docs": [
+              "Reserve liquidity cumulative borrow rate (scaled fraction)"
+            ],
+            "type": {
+              "defined": "BigFractionBytes"
+            }
+          },
+          {
+            "name": "accumulatedProtocolFeesSf",
+            "docs": [
+              "Reserve cumulative protocol fees (scaled fraction)"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "accumulatedReferrerFeesSf",
+            "docs": [
+              "Reserve cumulative referrer fees (scaled fraction)"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "pendingReferrerFeesSf",
+            "docs": [
+              "Reserve pending referrer fees, to be claimed in refresh_obligation by referrer or protocol (scaled fraction)"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "absoluteReferralRateSf",
+            "docs": [
+              "Reserve referrer fee absolute rate calculated at each refresh_reserve operation (scaled fraction)"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "tokenProgram",
+            "docs": [
+              "Token program of the liquidity mint"
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "padding2",
+            "type": {
+              "array": [
+                "u64",
+                51
+              ]
+            }
+          },
+          {
+            "name": "padding3",
+            "type": {
+              "array": [
+                "u128",
+                32
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ReserveStatus",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Active"
+          },
+          {
+            "name": "Obsolete"
+          },
+          {
+            "name": "Hidden"
+          }
+        ]
+      }
+    },
+    {
+      "name": "WithdrawalCaps",
+      "docs": [
+        "Reserve Withdrawal Caps State"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "configCapacity",
+            "type": "i64"
+          },
+          {
+            "name": "currentTotal",
+            "type": "i64"
+          },
+          {
+            "name": "lastIntervalStartTimestamp",
+            "type": "u64"
+          },
+          {
+            "name": "configIntervalLengthSeconds",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PriceHeuristic",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lower",
+            "docs": [
+              "Lower value of acceptable price"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "upper",
+            "docs": [
+              "Upper value of acceptable price"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "exp",
+            "docs": [
+              "Number of decimals of the previously defined values"
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PythConfiguration",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "price",
+            "docs": [
+              "Pubkey of the base price feed (disabled if `null` or `default`)"
+            ],
+            "type": "publicKey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ScopeConfiguration",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "priceFeed",
+            "docs": [
+              "Pubkey of the scope price feed (disabled if `null` or `default`)"
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "priceChain",
+            "docs": [
+              "This is the scope_id price chain that results in a price for the token"
+            ],
+            "type": {
+              "array": [
+                "u16",
+                4
+              ]
+            }
+          },
+          {
+            "name": "twapChain",
+            "docs": [
+              "This is the scope_id price chain for the twap"
+            ],
+            "type": {
+              "array": [
+                "u16",
+                4
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "SwitchboardConfiguration",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "priceAggregator",
+            "docs": [
+              "Pubkey of the base price feed (disabled if `null` or `default`)"
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "twapAggregator",
+            "type": "publicKey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "TokenInfo",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "name",
+            "docs": [
+              "UTF-8 encoded name of the token (null-terminated)"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "heuristic",
+            "docs": [
+              "Heuristics limits of acceptable price"
+            ],
+            "type": {
+              "defined": "PriceHeuristic"
+            }
+          },
+          {
+            "name": "maxTwapDivergenceBps",
+            "docs": [
+              "Max divergence between twap and price in bps"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "maxAgePriceSeconds",
+            "type": "u64"
+          },
+          {
+            "name": "maxAgeTwapSeconds",
+            "type": "u64"
+          },
+          {
+            "name": "scopeConfiguration",
+            "docs": [
+              "Scope price configuration"
+            ],
+            "type": {
+              "defined": "ScopeConfiguration"
+            }
+          },
+          {
+            "name": "switchboardConfiguration",
+            "docs": [
+              "Switchboard configuration"
+            ],
+            "type": {
+              "defined": "SwitchboardConfiguration"
+            }
+          },
+          {
+            "name": "pythConfiguration",
+            "docs": [
+              "Pyth configuration"
+            ],
+            "type": {
+              "defined": "PythConfiguration"
+            }
+          },
+          {
+            "name": "blockPriceUsage",
+            "type": "u8"
+          },
+          {
+            "name": "reserved",
+            "type": {
+              "array": [
+                "u8",
+                7
+              ]
+            }
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u64",
+                19
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "BorrowRateCurve",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "points",
+            "type": {
+              "array": [
+                {
+                  "defined": "CurvePoint"
+                },
+                11
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "CurvePoint",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "utilizationRateBps",
+            "type": "u32"
+          },
+          {
+            "name": "borrowRateBps",
+            "type": "u32"
+          }
+        ]
+      }
+    }
+  ],
+  "events": [
+    {
+      "name": "BorrowOrderCancelEvent",
+      "fields": [
+        {
+          "name": "before",
+          "type": {
+            "defined": "BorrowOrder"
+          },
+          "index": false
+        }
+      ]
+    },
+    {
+      "name": "BorrowOrderFullFillEvent",
+      "fields": [
+        {
+          "name": "before",
+          "type": {
+            "defined": "BorrowOrder"
+          },
+          "index": false
+        }
+      ]
+    },
+    {
+      "name": "BorrowOrderPartialFillEvent",
+      "fields": [
+        {
+          "name": "before",
+          "type": {
+            "defined": "BorrowOrder"
+          },
+          "index": false
+        },
+        {
+          "name": "after",
+          "type": {
+            "defined": "BorrowOrder"
+          },
+          "index": false
+        }
+      ]
+    },
+    {
+      "name": "BorrowOrderPlaceEvent",
+      "fields": [
+        {
+          "name": "after",
+          "type": {
+            "defined": "BorrowOrder"
+          },
+          "index": false
+        }
+      ]
+    },
+    {
+      "name": "BorrowOrderUpdateEvent",
+      "fields": [
+        {
+          "name": "before",
+          "type": {
+            "defined": "BorrowOrder"
+          },
+          "index": false
+        },
+        {
+          "name": "after",
+          "type": {
+            "defined": "BorrowOrder"
+          },
+          "index": false
+        }
+      ]
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "InvalidMarketAuthority",
+      "msg": "Market authority is invalid"
+    },
+    {
+      "code": 6001,
+      "name": "InvalidMarketOwner",
+      "msg": "Market owner is invalid"
+    },
+    {
+      "code": 6002,
+      "name": "InvalidAccountOwner",
+      "msg": "Input account owner is not the program address"
+    },
+    {
+      "code": 6003,
+      "name": "InvalidAmount",
+      "msg": "Input amount is invalid"
+    },
+    {
+      "code": 6004,
+      "name": "InvalidConfig",
+      "msg": "Input config value is invalid"
+    },
+    {
+      "code": 6005,
+      "name": "InvalidSigner",
+      "msg": "Signer is not allowed to perform this action"
+    },
+    {
+      "code": 6006,
+      "name": "InvalidAccountInput",
+      "msg": "Invalid account input"
+    },
+    {
+      "code": 6007,
+      "name": "MathOverflow",
+      "msg": "Math operation overflow"
+    },
+    {
+      "code": 6008,
+      "name": "InsufficientLiquidity",
+      "msg": "Insufficient liquidity available"
+    },
+    {
+      "code": 6009,
+      "name": "ReserveStale",
+      "msg": "Reserve state needs to be refreshed"
+    },
+    {
+      "code": 6010,
+      "name": "WithdrawTooSmall",
+      "msg": "Withdraw amount too small"
+    },
+    {
+      "code": 6011,
+      "name": "WithdrawTooLarge",
+      "msg": "Withdraw amount too large"
+    },
+    {
+      "code": 6012,
+      "name": "BorrowTooSmall",
+      "msg": "Borrow amount too small to receive liquidity after fees"
+    },
+    {
+      "code": 6013,
+      "name": "BorrowTooLarge",
+      "msg": "Borrow amount too large for deposited collateral"
+    },
+    {
+      "code": 6014,
+      "name": "RepayTooSmall",
+      "msg": "Repay amount too small to transfer liquidity"
+    },
+    {
+      "code": 6015,
+      "name": "LiquidationTooSmall",
+      "msg": "Liquidation amount too small to receive collateral"
+    },
+    {
+      "code": 6016,
+      "name": "ObligationHealthy",
+      "msg": "Cannot liquidate healthy obligations"
+    },
+    {
+      "code": 6017,
+      "name": "ObligationStale",
+      "msg": "Obligation state needs to be refreshed"
+    },
+    {
+      "code": 6018,
+      "name": "ObligationReserveLimit",
+      "msg": "Obligation reserve limit exceeded"
+    },
+    {
+      "code": 6019,
+      "name": "InvalidObligationOwner",
+      "msg": "Obligation owner is invalid"
+    },
+    {
+      "code": 6020,
+      "name": "ObligationDepositsEmpty",
+      "msg": "Obligation deposits are empty"
+    },
+    {
+      "code": 6021,
+      "name": "ObligationBorrowsEmpty",
+      "msg": "Obligation borrows are empty"
+    },
+    {
+      "code": 6022,
+      "name": "ObligationDepositsZero",
+      "msg": "Obligation deposits have zero value"
+    },
+    {
+      "code": 6023,
+      "name": "ObligationBorrowsZero",
+      "msg": "Obligation borrows have zero value"
+    },
+    {
+      "code": 6024,
+      "name": "InvalidObligationCollateral",
+      "msg": "Invalid obligation collateral"
+    },
+    {
+      "code": 6025,
+      "name": "InvalidObligationLiquidity",
+      "msg": "Invalid obligation liquidity"
+    },
+    {
+      "code": 6026,
+      "name": "ObligationCollateralEmpty",
+      "msg": "Obligation collateral is empty"
+    },
+    {
+      "code": 6027,
+      "name": "ObligationLiquidityEmpty",
+      "msg": "Obligation liquidity is empty"
+    },
+    {
+      "code": 6028,
+      "name": "NegativeInterestRate",
+      "msg": "Interest rate is negative"
+    },
+    {
+      "code": 6029,
+      "name": "InvalidOracleConfig",
+      "msg": "Input oracle config is invalid"
+    },
+    {
+      "code": 6030,
+      "name": "InsufficientProtocolFeesToRedeem",
+      "msg": "Insufficient protocol fees to claim or no liquidity available"
+    },
+    {
+      "code": 6031,
+      "name": "FlashBorrowCpi",
+      "msg": "No cpi flash borrows allowed"
+    },
+    {
+      "code": 6032,
+      "name": "NoFlashRepayFound",
+      "msg": "No corresponding repay found for flash borrow"
+    },
+    {
+      "code": 6033,
+      "name": "InvalidFlashRepay",
+      "msg": "Invalid repay found"
+    },
+    {
+      "code": 6034,
+      "name": "FlashRepayCpi",
+      "msg": "No cpi flash repays allowed"
+    },
+    {
+      "code": 6035,
+      "name": "MultipleFlashBorrows",
+      "msg": "Multiple flash borrows not allowed in the same transaction"
+    },
+    {
+      "code": 6036,
+      "name": "FlashLoansDisabled",
+      "msg": "Flash loans are disabled for this reserve"
+    },
+    {
+      "code": 6037,
+      "name": "SwitchboardV2Error",
+      "msg": "Switchboard error"
+    },
+    {
+      "code": 6038,
+      "name": "CouldNotDeserializeScope",
+      "msg": "Cannot deserialize the scope price account"
+    },
+    {
+      "code": 6039,
+      "name": "PriceTooOld",
+      "msg": "Price too old"
+    },
+    {
+      "code": 6040,
+      "name": "PriceTooDivergentFromTwap",
+      "msg": "Price too divergent from twap"
+    },
+    {
+      "code": 6041,
+      "name": "InvalidTwapPrice",
+      "msg": "Invalid twap price"
+    },
+    {
+      "code": 6042,
+      "name": "GlobalEmergencyMode",
+      "msg": "Emergency mode is enabled"
+    },
+    {
+      "code": 6043,
+      "name": "InvalidFlag",
+      "msg": "Invalid lending market config"
+    },
+    {
+      "code": 6044,
+      "name": "PriceNotValid",
+      "msg": "Price is not valid"
+    },
+    {
+      "code": 6045,
+      "name": "PriceIsBiggerThanHeuristic",
+      "msg": "Price is bigger than allowed by heuristic"
+    },
+    {
+      "code": 6046,
+      "name": "PriceIsLowerThanHeuristic",
+      "msg": "Price lower than allowed by heuristic"
+    },
+    {
+      "code": 6047,
+      "name": "PriceIsZero",
+      "msg": "Price is zero"
+    },
+    {
+      "code": 6048,
+      "name": "PriceConfidenceTooWide",
+      "msg": "Price confidence too wide"
+    },
+    {
+      "code": 6049,
+      "name": "IntegerOverflow",
+      "msg": "Conversion between integers failed"
+    },
+    {
+      "code": 6050,
+      "name": "NoFarmForReserve",
+      "msg": "This reserve does not have a farm"
+    },
+    {
+      "code": 6051,
+      "name": "IncorrectInstructionInPosition",
+      "msg": "Wrong instruction at expected position"
+    },
+    {
+      "code": 6052,
+      "name": "NoPriceFound",
+      "msg": "No price found"
+    },
+    {
+      "code": 6053,
+      "name": "InvalidTwapConfig",
+      "msg": "Invalid Twap configuration: Twap is enabled but one of the enabled price doesn't have a twap"
+    },
+    {
+      "code": 6054,
+      "name": "InvalidPythPriceAccount",
+      "msg": "Pyth price account does not match configuration"
+    },
+    {
+      "code": 6055,
+      "name": "InvalidSwitchboardAccount",
+      "msg": "Switchboard account(s) do not match configuration"
+    },
+    {
+      "code": 6056,
+      "name": "InvalidScopePriceAccount",
+      "msg": "Scope price account does not match configuration"
+    },
+    {
+      "code": 6057,
+      "name": "ObligationCollateralLtvZero",
+      "msg": "The obligation has one collateral with an LTV set to 0. Withdraw it before withdrawing other collaterals"
+    },
+    {
+      "code": 6058,
+      "name": "InvalidObligationSeedsValue",
+      "msg": "Seeds must be default pubkeys for tag 0, and mint addresses for tag 1 or 2"
+    },
+    {
+      "code": 6059,
+      "name": "DeprecatedInvalidObligationId",
+      "msg": "[DEPRECATED] Obligation id must be 0"
+    },
+    {
+      "code": 6060,
+      "name": "InvalidBorrowRateCurvePoint",
+      "msg": "Invalid borrow rate curve point"
+    },
+    {
+      "code": 6061,
+      "name": "InvalidUtilizationRate",
+      "msg": "Invalid utilization rate"
+    },
+    {
+      "code": 6062,
+      "name": "CannotSocializeObligationWithCollateral",
+      "msg": "Obligation hasn't been fully liquidated and debt cannot be socialized."
+    },
+    {
+      "code": 6063,
+      "name": "ObligationEmpty",
+      "msg": "Obligation has no borrows or deposits."
+    },
+    {
+      "code": 6064,
+      "name": "WithdrawalCapReached",
+      "msg": "Withdrawal cap is reached"
+    },
+    {
+      "code": 6065,
+      "name": "LastTimestampGreaterThanCurrent",
+      "msg": "The last interval start timestamp is greater than the current timestamp"
+    },
+    {
+      "code": 6066,
+      "name": "LiquidationRewardTooSmall",
+      "msg": "The reward amount is less than the minimum acceptable received liquidity"
+    },
+    {
+      "code": 6067,
+      "name": "IsolatedAssetTierViolation",
+      "msg": "Isolated Asset Tier Violation"
+    },
+    {
+      "code": 6068,
+      "name": "InconsistentElevationGroup",
+      "msg": "The obligation's elevation group and the reserve's are not the same"
+    },
+    {
+      "code": 6069,
+      "name": "InvalidElevationGroup",
+      "msg": "The elevation group chosen for the reserve does not exist in the lending market"
+    },
+    {
+      "code": 6070,
+      "name": "InvalidElevationGroupConfig",
+      "msg": "The elevation group updated has wrong parameters set"
+    },
+    {
+      "code": 6071,
+      "name": "UnhealthyElevationGroupLtv",
+      "msg": "The current obligation must have most or all its debt repaid before changing the elevation group"
+    },
+    {
+      "code": 6072,
+      "name": "ElevationGroupNewLoansDisabled",
+      "msg": "Elevation group does not accept any new loans or any new borrows/withdrawals"
+    },
+    {
+      "code": 6073,
+      "name": "ReserveDeprecated",
+      "msg": "Reserve was deprecated, no longer usable"
+    },
+    {
+      "code": 6074,
+      "name": "ReferrerAccountNotInitialized",
+      "msg": "Referrer account not initialized"
+    },
+    {
+      "code": 6075,
+      "name": "ReferrerAccountMintMissmatch",
+      "msg": "Referrer account mint does not match the operation reserve mint"
+    },
+    {
+      "code": 6076,
+      "name": "ReferrerAccountWrongAddress",
+      "msg": "Referrer account address is not a valid program address"
+    },
+    {
+      "code": 6077,
+      "name": "ReferrerAccountReferrerMissmatch",
+      "msg": "Referrer account referrer does not match the owner referrer"
+    },
+    {
+      "code": 6078,
+      "name": "ReferrerAccountMissing",
+      "msg": "Referrer account missing for obligation with referrer"
+    },
+    {
+      "code": 6079,
+      "name": "InsufficientReferralFeesToRedeem",
+      "msg": "Insufficient referral fees to claim or no liquidity available"
+    },
+    {
+      "code": 6080,
+      "name": "CpiDisabled",
+      "msg": "CPI disabled for this instruction"
+    },
+    {
+      "code": 6081,
+      "name": "ShortUrlNotAsciiAlphanumeric",
+      "msg": "Referrer short_url is not ascii alphanumeric"
+    },
+    {
+      "code": 6082,
+      "name": "ReserveObsolete",
+      "msg": "Reserve is marked as obsolete"
+    },
+    {
+      "code": 6083,
+      "name": "ElevationGroupAlreadyActivated",
+      "msg": "Obligation already part of the same elevation group"
+    },
+    {
+      "code": 6084,
+      "name": "ObligationInObsoleteReserve",
+      "msg": "Obligation has a deposit or borrow in an obsolete reserve"
+    },
+    {
+      "code": 6085,
+      "name": "ReferrerStateOwnerMismatch",
+      "msg": "Referrer state owner does not match the given signer"
+    },
+    {
+      "code": 6086,
+      "name": "UserMetadataOwnerAlreadySet",
+      "msg": "User metadata owner is already set"
+    },
+    {
+      "code": 6087,
+      "name": "CollateralNonLiquidatable",
+      "msg": "This collateral cannot be liquidated (LTV set to 0)"
+    },
+    {
+      "code": 6088,
+      "name": "BorrowingDisabled",
+      "msg": "Borrowing is disabled"
+    },
+    {
+      "code": 6089,
+      "name": "BorrowLimitExceeded",
+      "msg": "Cannot borrow above borrow limit"
+    },
+    {
+      "code": 6090,
+      "name": "DepositLimitExceeded",
+      "msg": "Cannot deposit above deposit limit"
+    },
+    {
+      "code": 6091,
+      "name": "BorrowingDisabledOutsideElevationGroup",
+      "msg": "Reserve does not accept any new borrows outside elevation group"
+    },
+    {
+      "code": 6092,
+      "name": "NetValueRemainingTooSmall",
+      "msg": "Net value remaining too small"
+    },
+    {
+      "code": 6093,
+      "name": "WorseLtvBlocked",
+      "msg": "Cannot get the obligation in a worse position"
+    },
+    {
+      "code": 6094,
+      "name": "LiabilitiesBiggerThanAssets",
+      "msg": "Cannot have more liabilities than assets in a position"
+    },
+    {
+      "code": 6095,
+      "name": "ReserveTokenBalanceMismatch",
+      "msg": "Reserve state and token account cannot drift"
+    },
+    {
+      "code": 6096,
+      "name": "ReserveVaultBalanceMismatch",
+      "msg": "Reserve token account has been unexpectedly modified"
+    },
+    {
+      "code": 6097,
+      "name": "ReserveAccountingMismatch",
+      "msg": "Reserve internal state accounting has been unexpectedly modified"
+    },
+    {
+      "code": 6098,
+      "name": "BorrowingAboveUtilizationRateDisabled",
+      "msg": "Borrowing above set utilization rate is disabled"
+    },
+    {
+      "code": 6099,
+      "name": "LiquidationBorrowFactorPriority",
+      "msg": "Liquidation must prioritize the debt with the highest borrow factor"
+    },
+    {
+      "code": 6100,
+      "name": "LiquidationLowestLiquidationLtvPriority",
+      "msg": "Liquidation must prioritize the collateral with the lowest liquidation LTV"
+    },
+    {
+      "code": 6101,
+      "name": "ElevationGroupBorrowLimitExceeded",
+      "msg": "Elevation group borrow limit exceeded"
+    },
+    {
+      "code": 6102,
+      "name": "ElevationGroupWithoutDebtReserve",
+      "msg": "The elevation group does not have a debt reserve defined"
+    },
+    {
+      "code": 6103,
+      "name": "ElevationGroupMaxCollateralReserveZero",
+      "msg": "The elevation group does not allow any collateral reserves"
+    },
+    {
+      "code": 6104,
+      "name": "ElevationGroupHasAnotherDebtReserve",
+      "msg": "In elevation group attempt to borrow from a reserve that is not the debt reserve"
+    },
+    {
+      "code": 6105,
+      "name": "ElevationGroupDebtReserveAsCollateral",
+      "msg": "The elevation group's debt reserve cannot be used as a collateral reserve"
+    },
+    {
+      "code": 6106,
+      "name": "ObligationCollateralExceedsElevationGroupLimit",
+      "msg": "Obligation have more collateral than the maximum allowed by the elevation group"
+    },
+    {
+      "code": 6107,
+      "name": "ObligationElevationGroupMultipleDebtReserve",
+      "msg": "Obligation is an elevation group but have more than one debt reserve"
+    },
+    {
+      "code": 6108,
+      "name": "UnsupportedTokenExtension",
+      "msg": "Mint has a token (2022) extension that is not supported"
+    },
+    {
+      "code": 6109,
+      "name": "InvalidTokenAccount",
+      "msg": "Can't have an spl token mint with a t22 account"
+    },
+    {
+      "code": 6110,
+      "name": "DepositDisabledOutsideElevationGroup",
+      "msg": "Can't deposit into this reserve outside elevation group"
+    },
+    {
+      "code": 6111,
+      "name": "CannotCalculateReferralAmountDueToSlotsMismatch",
+      "msg": "Cannot calculate referral amount due to slots mismatch"
+    },
+    {
+      "code": 6112,
+      "name": "ObligationOwnersMustMatch",
+      "msg": "Obligation owners must match"
+    },
+    {
+      "code": 6113,
+      "name": "ObligationsMustMatch",
+      "msg": "Obligations must match"
+    },
+    {
+      "code": 6114,
+      "name": "LendingMarketsMustMatch",
+      "msg": "Lending markets must match"
+    },
+    {
+      "code": 6115,
+      "name": "ObligationCurrentlyMarkedForDeleveraging",
+      "msg": "Obligation is already marked for deleveraging"
+    },
+    {
+      "code": 6116,
+      "name": "MaximumWithdrawValueZero",
+      "msg": "Maximum withdrawable value of this collateral is zero, LTV needs improved"
+    },
+    {
+      "code": 6117,
+      "name": "ZeroMaxLtvAssetsInDeposits",
+      "msg": "No max LTV 0 assets allowed in deposits for repay and withdraw"
+    },
+    {
+      "code": 6118,
+      "name": "LowestLtvAssetsPriority",
+      "msg": "Withdrawing must prioritize the collateral with the lowest reserve max-LTV"
+    },
+    {
+      "code": 6119,
+      "name": "WorseLtvThanUnhealthyLtv",
+      "msg": "Cannot get the obligation liquidatable"
+    },
+    {
+      "code": 6120,
+      "name": "FarmAccountsMissing",
+      "msg": "Farm accounts to refresh are missing"
+    },
+    {
+      "code": 6121,
+      "name": "RepayTooSmallForFullLiquidation",
+      "msg": "Repay amount is too small to satisfy the mandatory full liquidation"
+    },
+    {
+      "code": 6122,
+      "name": "InsufficientRepayAmount",
+      "msg": "Liquidator provided repay amount lower than required by liquidation rules"
+    },
+    {
+      "code": 6123,
+      "name": "OrderIndexOutOfBounds",
+      "msg": "Obligation order of the given index cannot exist"
+    },
+    {
+      "code": 6124,
+      "name": "InvalidOrderConfiguration",
+      "msg": "Given order configuration has wrong parameters"
+    },
+    {
+      "code": 6125,
+      "name": "OrderConfigurationNotSupportedByObligation",
+      "msg": "Given order configuration cannot be used with the current state of the obligation"
+    },
+    {
+      "code": 6126,
+      "name": "OperationNotPermittedWithCurrentObligationOrders",
+      "msg": "Single debt, single collateral obligation orders have to be cancelled before changing the deposit/borrow count"
+    },
+    {
+      "code": 6127,
+      "name": "OperationNotPermittedMarketImmutable",
+      "msg": "Cannot update lending market because it is set as immutable"
+    },
+    {
+      "code": 6128,
+      "name": "OrderCreationDisabled",
+      "msg": "Creation of new orders is disabled"
+    },
+    {
+      "code": 6129,
+      "name": "NoUpgradeAuthority",
+      "msg": "Cannot initialize global config because there is no upgrade authority to the program"
+    },
+    {
+      "code": 6130,
+      "name": "InitialAdminDepositExecuted",
+      "msg": "Initial admin deposit in reserve already executed"
+    },
+    {
+      "code": 6131,
+      "name": "ReserveHasNotReceivedInitialDeposit",
+      "msg": "Reserve has not received the initial deposit, cannot update config"
+    },
+    {
+      "code": 6132,
+      "name": "CTokenUsageBlocked",
+      "msg": "CToken minting/redeeming is blocked for this reserve"
+    },
+    {
+      "code": 6133,
+      "name": "CannotUseSameReserve",
+      "msg": "Cannot call ix with same reserve"
+    },
+    {
+      "code": 6134,
+      "name": "TransactionIncludesRestrictedPrograms",
+      "msg": "Transaction includes restricted programs"
+    },
+    {
+      "code": 6135,
+      "name": "BorrowOrderDebtLiquidityMintMismatch",
+      "msg": "There is no borrow order requesting debt in the given asset"
+    },
+    {
+      "code": 6136,
+      "name": "BorrowOrderMaxBorrowRateExceeded",
+      "msg": "Reserve used for fill exceeds the maximum borrow rate specified by the order"
+    },
+    {
+      "code": 6137,
+      "name": "BorrowOrderMinDebtTermInsufficient",
+      "msg": "Reserve used for fill defines a debt term shorter than specified by the order"
+    },
+    {
+      "code": 6138,
+      "name": "BorrowOrderFillTimeLimitExceeded",
+      "msg": "Borrow order can no longer be filled"
+    },
+    {
+      "code": 6139,
+      "name": "ReserveDebtMaturityReached",
+      "msg": "Cannot borrow from a reserve that reached its debt maturity timestamp"
+    },
+    {
+      "code": 6140,
+      "name": "NonUpdatableOrderConfiguration",
+      "msg": "Some piece of the order's configuration cannot be updated (the order should be cancelled and placed again)"
+    },
+    {
+      "code": 6141,
+      "name": "BorrowOrderExecutionDisabled",
+      "msg": "Execution of borrow orders is disabled"
+    },
+    {
+      "code": 6142,
+      "name": "DebtReachedReserveDebtTerm",
+      "msg": "Cannot increase the debt that has reached its end of term configured by the reserve"
+    },
+    {
+      "code": 6143,
+      "name": "ExpectationNotMet",
+      "msg": "The on-chain state does not meet expectation specified by the caller, so the operation must be aborted (to avoid race conditions)"
+    }
+  ]
+}

--- a/kamino_sample.json
+++ b/kamino_sample.json
@@ -1,0 +1,37 @@
+{
+  "collateral": [
+    {
+      "symbol": "SOL",
+      "amount": 10,
+      "price": 150,
+      "ltv": 0.6,
+      "liquidation_threshold": 0.7
+    },
+    {
+      "symbol": "USDC",
+      "amount": 500,
+      "price": 1,
+      "ltv": 0.8,
+      "liquidation_threshold": 0.9
+    }
+  ],
+  "debt": [
+    {
+      "symbol": "USDC",
+      "amount": 900,
+      "price": 1
+    }
+  ],
+  "actions": [
+    {
+      "type": "borrow",
+      "symbol": "USDC",
+      "amount": 100
+    },
+    {
+      "type": "update_price",
+      "symbol": "SOL",
+      "price": 130
+    }
+  ]
+}

--- a/kamino_sim.py
+++ b/kamino_sim.py
@@ -1,6 +1,9 @@
 import argparse
 import json
+import os
 from typing import Any, Dict, List, Optional
+
+from dotenv import load_dotenv
 
 from arblab.kamino_risk import (
     AccountSnapshot,
@@ -68,15 +71,17 @@ def run_simulation(payload: Dict[str, Any]) -> str:
 
 
 def main() -> None:
+    load_dotenv()
+
     parser = argparse.ArgumentParser(description="Kamino liquidation risk simulator.")
     parser.add_argument("--input", help="Path to JSON file with collateral/debt data.")
     parser.add_argument("--obligation", help="Kamino obligation account address.")
     parser.add_argument(
         "--program-id",
-        default="KLend2g3cP87fffoy8q1mQqGKjrxjC8boSyAYavgmjD",
+        default=os.getenv("KAMINO_PROGRAM_ID", "KLend2g3cP87fffoy8q1mQqGKjrxjC8boSyAYavgmjD"),
         help="Kamino lending program id (default: mainnet KLend).",
     )
-    parser.add_argument("--rpc-url", default="https://api.mainnet-beta.solana.com")
+    parser.add_argument("--rpc-url", default=os.getenv("SOLANA_RPC_URL", "https://api.mainnet-beta.solana.com"))
     parser.add_argument("--idl", help="Path to Kamino Anchor IDL JSON for decoding accounts.")
     parser.add_argument("--obligation-account-name", default="Obligation")
     parser.add_argument("--reserve-account-name", default="Reserve")

--- a/kamino_sim.py
+++ b/kamino_sim.py
@@ -1,0 +1,122 @@
+import argparse
+import json
+from typing import Any, Dict, List, Optional
+
+from arblab.kamino_risk import (
+    AccountSnapshot,
+    CollateralPosition,
+    DebtPosition,
+    apply_actions,
+    liquidation_prices,
+    scenario_report,
+)
+from arblab.kamino_onchain import load_onchain_snapshot
+
+
+def _parse_snapshot(payload: Dict[str, Any]) -> AccountSnapshot:
+    collateral = [
+        CollateralPosition(
+            symbol=item["symbol"],
+            amount=float(item["amount"]),
+            price=float(item["price"]),
+            ltv=float(item["ltv"]),
+            liquidation_threshold=float(item["liquidation_threshold"]),
+        )
+        for item in payload.get("collateral", [])
+    ]
+    debt = [
+        DebtPosition(
+            symbol=item["symbol"],
+            amount=float(item["amount"]),
+            price=float(item["price"]),
+        )
+        for item in payload.get("debt", [])
+    ]
+    return AccountSnapshot(collateral=collateral, debt=debt)
+
+
+def _format_report(title: str, report: Dict[str, float]) -> str:
+    lines = [title]
+    for key, value in report.items():
+        lines.append(f"  {key}: {value:.6f}")
+    return "\n".join(lines)
+
+
+def run_simulation(payload: Dict[str, Any]) -> str:
+    snapshot = _parse_snapshot(payload)
+    baseline_report = scenario_report(snapshot)
+    baseline_prices = liquidation_prices(snapshot)
+
+    actions: List[Dict[str, float]] = payload.get("actions", [])
+    if actions:
+        snapshot = apply_actions(snapshot, actions)
+    scenario = scenario_report(snapshot)
+    scenario_prices = liquidation_prices(snapshot)
+
+    output = [
+        _format_report("Baseline:", baseline_report),
+        json.dumps({"baseline_liquidation_prices": baseline_prices}, indent=2),
+    ]
+    if actions:
+        output.extend(
+            [
+                _format_report("After actions:", scenario),
+                json.dumps({"scenario_liquidation_prices": scenario_prices}, indent=2),
+            ]
+        )
+    return "\n".join(output)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Kamino liquidation risk simulator.")
+    parser.add_argument("--input", help="Path to JSON file with collateral/debt data.")
+    parser.add_argument("--obligation", help="Kamino obligation account address.")
+    parser.add_argument("--program-id", help="Kamino lending program id (anchor program).")
+    parser.add_argument("--rpc-url", default="https://api.mainnet-beta.solana.com")
+    parser.add_argument("--idl", help="Path to Kamino Anchor IDL JSON for decoding accounts.")
+    parser.add_argument("--obligation-account-name", default="obligation")
+    parser.add_argument("--reserve-account-name", default="reserve")
+    args = parser.parse_args()
+
+    payload: Optional[Dict[str, Any]] = None
+    if args.input:
+        with open(args.input, "r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+    elif args.obligation and args.program_id and args.idl:
+        snapshot = load_onchain_snapshot(
+            obligation_address=args.obligation,
+            program_id=args.program_id,
+            rpc_url=args.rpc_url,
+            idl_path=args.idl,
+            obligation_account_name=args.obligation_account_name,
+            reserve_account_name=args.reserve_account_name,
+        )
+        payload = {
+            "collateral": [
+                {
+                    "symbol": position.symbol,
+                    "amount": position.amount,
+                    "price": position.price,
+                    "ltv": position.ltv,
+                    "liquidation_threshold": position.liquidation_threshold,
+                }
+                for position in snapshot.collateral
+            ],
+            "debt": [
+                {
+                    "symbol": position.symbol,
+                    "amount": position.amount,
+                    "price": position.price,
+                }
+                for position in snapshot.debt
+            ],
+            "actions": [],
+        }
+    else:
+        parser.error("Provide --input or all of --obligation, --program-id, and --idl.")
+
+    print(run_simulation(payload))
+
+
+if __name__ == "__main__":
+    main()

--- a/kamino_sim.py
+++ b/kamino_sim.py
@@ -71,11 +71,15 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Kamino liquidation risk simulator.")
     parser.add_argument("--input", help="Path to JSON file with collateral/debt data.")
     parser.add_argument("--obligation", help="Kamino obligation account address.")
-    parser.add_argument("--program-id", help="Kamino lending program id (anchor program).")
+    parser.add_argument(
+        "--program-id",
+        default="KLend2g3cP87fffoy8q1mQqGKjrxjC8boSyAYavgmjD",
+        help="Kamino lending program id (default: mainnet KLend).",
+    )
     parser.add_argument("--rpc-url", default="https://api.mainnet-beta.solana.com")
     parser.add_argument("--idl", help="Path to Kamino Anchor IDL JSON for decoding accounts.")
-    parser.add_argument("--obligation-account-name", default="obligation")
-    parser.add_argument("--reserve-account-name", default="reserve")
+    parser.add_argument("--obligation-account-name", default="Obligation")
+    parser.add_argument("--reserve-account-name", default="Reserve")
     args = parser.parse_args()
 
     payload: Optional[Dict[str, Any]] = None

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+testpaths = tests
+markers =
+    scenario: multi-step DeFi scenario tests
+    functional: browser-based functional tests
+addopts = -p no:anchorpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ anchorpy==0.20.1
 solana>=0.33.0
 streamlit
 base58
+pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@ anchorpy==0.20.1
 solana>=0.33.0
 streamlit
 base58
+python-dotenv
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 ccxt==1.13.32
 numpy==1.14.1
 pandas==0.22.0
+anchorpy==0.20.1
+solana==0.30.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
-ccxt==1.13.32
-numpy==1.14.1
-pandas==0.22.0
+ccxt
+numpy
+pandas
 anchorpy==0.20.1
-solana==0.30.2
+solana>=0.33.0
+streamlit
+base58

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,34 @@
+"""Shared test helpers for Kamino Risk Simulator tests."""
+
+from arblab.kamino_risk import AccountSnapshot, CollateralPosition, DebtPosition
+
+
+def make_collateral(
+    symbol: str = "SOL",
+    amount: float = 10.0,
+    price: float = 150.0,
+    ltv: float = 0.65,
+    liq_threshold: float = 0.75,
+) -> CollateralPosition:
+    return CollateralPosition(
+        symbol=symbol, amount=amount, price=price,
+        ltv=ltv, liquidation_threshold=liq_threshold,
+    )
+
+
+def make_debt(
+    symbol: str = "USDC",
+    amount: float = 500.0,
+    price: float = 1.0,
+) -> DebtPosition:
+    return DebtPosition(symbol=symbol, amount=amount, price=price)
+
+
+def make_snapshot(
+    collateral: list[CollateralPosition] | None = None,
+    debt: list[DebtPosition] | None = None,
+) -> AccountSnapshot:
+    return AccountSnapshot(
+        collateral=collateral or [],
+        debt=debt or [],
+    )

--- a/tests/test_app_functional.py
+++ b/tests/test_app_functional.py
@@ -1,0 +1,111 @@
+"""Playwright-based functional tests for the Kamino Risk Simulator Streamlit app.
+
+These tests verify that the app starts and renders its initial UI correctly.
+They do NOT require any RPC calls -- they only check the unloaded state.
+
+Run with:  pytest tests/test_app_functional.py -m functional
+"""
+
+import subprocess
+import time
+
+import pytest
+from playwright.sync_api import sync_playwright
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def app_url():
+    """Start the Streamlit app on port 8502 for testing."""
+    proc = subprocess.Popen(
+        [
+            "streamlit", "run", "kamino_app.py",
+            "--server.port", "8502",
+            "--server.headless", "true",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    time.sleep(5)  # Wait for the server to be ready
+    yield "http://localhost:8502"
+    proc.terminate()
+    proc.wait()
+
+
+@pytest.fixture(scope="module")
+def browser_page(app_url):
+    """Launch a headless Chromium browser and provide a page pointed at the app."""
+    with sync_playwright() as pw:
+        browser = pw.chromium.launch()
+        page = browser.new_page()
+        page.goto(app_url, wait_until="networkidle")
+        yield page
+        browser.close()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.functional
+def test_initial_load(browser_page):
+    """The page title should contain 'Kamino'."""
+    title = browser_page.title()
+    assert "Kamino" in title, f"Expected 'Kamino' in page title, got: {title}"
+
+
+@pytest.mark.functional
+def test_wallet_input_exists(browser_page):
+    """The sidebar should contain a text input for the wallet address."""
+    sidebar = browser_page.locator('[data-testid="stSidebar"]')
+    wallet_input = sidebar.locator('input[type="text"]').first
+    assert wallet_input.is_visible(), "Wallet text input not found in sidebar"
+
+
+@pytest.mark.functional
+def test_instructions_shown(browser_page):
+    """An info message should prompt the user to enter an address."""
+    info_text = browser_page.locator("text=Enter a wallet or obligation address")
+    assert info_text.is_visible(), "Instruction text not found on initial load"
+
+
+@pytest.mark.functional
+def test_scenario_simulator_not_shown_without_data(browser_page):
+    """The Scenario Simulator section should not appear before loading data."""
+    scenario_header = browser_page.locator("text=Scenario Simulator")
+    assert scenario_header.count() == 0, "Scenario Simulator should not be visible without loaded data"
+
+
+@pytest.mark.functional
+def test_sidebar_title(browser_page):
+    """The sidebar should display the 'Kamino Risk Sim' title."""
+    sidebar = browser_page.locator('[data-testid="stSidebar"]')
+    title = sidebar.locator("text=Kamino Risk Sim")
+    assert title.is_visible(), "Sidebar title 'Kamino Risk Sim' not found"
+
+
+@pytest.mark.functional
+def test_load_by_radio_buttons(browser_page):
+    """The sidebar should have radio options for 'Wallet address' and 'Obligation address'."""
+    wallet_radio = browser_page.locator("text=Wallet address")
+    obligation_radio = browser_page.locator("text=Obligation address")
+    assert wallet_radio.count() >= 1, "Wallet address radio option not found"
+    assert obligation_radio.count() >= 1, "Obligation address radio option not found"
+
+
+@pytest.mark.functional
+def test_load_positions_button_exists(browser_page):
+    """The sidebar should have a 'Load positions' button."""
+    sidebar = browser_page.locator('[data-testid="stSidebar"]')
+    button = sidebar.locator('button:has-text("Load positions")')
+    assert button.is_visible(), "Load positions button not found in sidebar"
+
+
+@pytest.mark.functional
+def test_main_heading(browser_page):
+    """The main area should show the 'Kamino Liquidation Risk Simulator' heading."""
+    heading = browser_page.locator("text=Kamino Liquidation Risk Simulator")
+    assert heading.is_visible(), "Main heading not found on page"

--- a/tests/test_kamino_onchain.py
+++ b/tests/test_kamino_onchain.py
@@ -1,0 +1,124 @@
+"""Unit tests for pure calculation functions in arblab.kamino_onchain."""
+
+from decimal import Decimal
+from types import SimpleNamespace
+
+from arblab.kamino_onchain import (
+    SF_SCALE,
+    _compute_collateral_exchange_rate,
+    _normalize_amount,
+    _sf_to_decimal,
+)
+
+
+# ---------------------------------------------------------------------------
+# _sf_to_decimal
+# ---------------------------------------------------------------------------
+
+class TestSfToDecimal:
+    def test_zero(self):
+        assert _sf_to_decimal(0) == Decimal(0)
+
+    def test_one_scale_factor(self):
+        """2**60 in Sf representation equals 1."""
+        assert _sf_to_decimal(2**60) == Decimal(1)
+
+    def test_two(self):
+        """2**61 in Sf representation equals 2."""
+        assert _sf_to_decimal(2**61) == Decimal(2)
+
+    def test_half(self):
+        """2**59 in Sf representation equals 0.5."""
+        assert _sf_to_decimal(2**59) == Decimal("0.5")
+
+    def test_large_128_bit_number(self):
+        """Verify correct handling of a large 128-bit Sf value.
+
+        A value near the upper end of 128-bit range:
+        2**127 / 2**60 = 2**67 = 147573952589676412928
+        """
+        sf_value = 2**127
+        expected = Decimal(2**67)
+        assert _sf_to_decimal(sf_value) == expected
+
+
+# ---------------------------------------------------------------------------
+# _normalize_amount
+# ---------------------------------------------------------------------------
+
+class TestNormalizeAmount:
+    def test_usdc_one_token(self):
+        """1_000_000 raw units with 6 decimals (USDC) equals 1."""
+        assert _normalize_amount(1_000_000, 6) == Decimal(1)
+
+    def test_sol_one_token(self):
+        """1_000_000_000 raw units with 9 decimals (SOL) equals 1."""
+        assert _normalize_amount(1_000_000_000, 9) == Decimal(1)
+
+    def test_zero_amount(self):
+        assert _normalize_amount(0, 6) == Decimal(0)
+
+    def test_fractional_usdc(self):
+        """500_000 raw units with 6 decimals equals 0.5."""
+        assert _normalize_amount(500_000, 6) == Decimal("0.5")
+
+
+# ---------------------------------------------------------------------------
+# _compute_collateral_exchange_rate
+# ---------------------------------------------------------------------------
+
+def _make_reserve(
+    available_amount: int = 0,
+    borrowed_amount_sf: int = 0,
+    accumulated_protocol_fees_sf: int = 0,
+    accumulated_referrer_fees_sf: int = 0,
+    pending_referrer_fees_sf: int = 0,
+    mint_total_supply: int = 0,
+) -> SimpleNamespace:
+    """Build a minimal reserve-like object using SimpleNamespace."""
+    return SimpleNamespace(
+        liquidity=SimpleNamespace(
+            available_amount=available_amount,
+            borrowed_amount_sf=borrowed_amount_sf,
+            accumulated_protocol_fees_sf=accumulated_protocol_fees_sf,
+            accumulated_referrer_fees_sf=accumulated_referrer_fees_sf,
+            pending_referrer_fees_sf=pending_referrer_fees_sf,
+        ),
+        collateral=SimpleNamespace(mint_total_supply=mint_total_supply),
+    )
+
+
+class TestComputeCollateralExchangeRate:
+    def test_one_to_one(self):
+        """When available equals mint supply and no fees/borrows, rate is 1."""
+        reserve = _make_reserve(
+            available_amount=1_000_000,
+            mint_total_supply=1_000_000,
+        )
+        assert _compute_collateral_exchange_rate(reserve) == Decimal(1)
+
+    def test_zero_mint_supply_returns_one(self):
+        """When mint_total_supply is 0 the function returns Decimal(1) as a fallback."""
+        reserve = _make_reserve(
+            available_amount=500_000,
+            borrowed_amount_sf=int(SF_SCALE) * 200,
+            mint_total_supply=0,
+        )
+        assert _compute_collateral_exchange_rate(reserve) == Decimal(1)
+
+    def test_with_fees(self):
+        """Exchange rate accounts for borrowed amounts and protocol fees.
+
+        available=1000, borrowed_sf=SF_SCALE*500 (=500), protocol_fees_sf=SF_SCALE*100 (=100),
+        referrer_fees=0, pending_fees=0, mint_supply=700.
+        Result: (1000 + 500 - 100 - 0 - 0) / 700 = 1400 / 700 = 2
+        """
+        reserve = _make_reserve(
+            available_amount=1000,
+            borrowed_amount_sf=int(SF_SCALE) * 500,
+            accumulated_protocol_fees_sf=int(SF_SCALE) * 100,
+            accumulated_referrer_fees_sf=0,
+            pending_referrer_fees_sf=0,
+            mint_total_supply=700,
+        )
+        assert _compute_collateral_exchange_rate(reserve) == Decimal(2)

--- a/tests/test_kamino_recovery.py
+++ b/tests/test_kamino_recovery.py
@@ -1,0 +1,245 @@
+"""Unit tests for arblab.kamino_recovery pure functions."""
+
+import pytest
+from pytest import approx
+
+from arblab.kamino_recovery import (
+    auto_loop_deposit,
+    collateral_rebalance,
+    compute_deficit,
+    recovery_deposit_tokens,
+    recovery_repay_usd,
+    recovery_swap_withdraw,
+)
+from arblab.kamino_risk import apply_actions, AccountSnapshot
+from tests.conftest import make_collateral, make_debt, make_snapshot
+
+
+# ---------------------------------------------------------------------------
+# compute_deficit
+# ---------------------------------------------------------------------------
+
+class TestComputeDeficit:
+    def test_positive_deficit_needs_recovery(self):
+        """Debt outweighs liq_value at target HF => positive deficit."""
+        # target_hf * debt - liq_value = 1.25 * 1000 - 750 = 500
+        assert compute_deficit(1000, 750, 1.25) == approx(500.0)
+
+    def test_zero_deficit_exactly_at_target(self):
+        """Position is exactly at target HF => zero deficit."""
+        # 1.5 * 1000 - 1500 = 0
+        assert compute_deficit(1000, 1500, 1.5) == approx(0.0)
+
+    def test_negative_deficit_already_safe(self):
+        """liq_value exceeds target => negative deficit (already safe)."""
+        # 1.0 * 500 - 800 = -300
+        assert compute_deficit(500, 800, 1.0) == approx(-300.0)
+
+    def test_zero_debt(self):
+        """No debt => deficit is negative (surplus)."""
+        assert compute_deficit(0, 500, 1.5) == approx(-500.0)
+
+    def test_zero_liq_value(self):
+        """No collateral liq_value => deficit equals target_hf * debt."""
+        assert compute_deficit(1000, 0, 1.25) == approx(1250.0)
+
+
+# ---------------------------------------------------------------------------
+# recovery_repay_usd
+# ---------------------------------------------------------------------------
+
+class TestRecoveryRepayUsd:
+    def test_basic_calculation(self):
+        """Straightforward repayment to reach target HF."""
+        # repay = debt - liq_value / target_hf = 1000 - 750/1.25 = 1000 - 600 = 400
+        assert recovery_repay_usd(1000, 750, 1.25) == approx(400.0)
+
+    def test_target_hf_zero_returns_zero(self):
+        """target_hf=0 guard returns 0."""
+        assert recovery_repay_usd(1000, 750, 0) == approx(0.0)
+
+    def test_target_hf_negative_returns_zero(self):
+        """Negative target_hf returns 0."""
+        assert recovery_repay_usd(1000, 750, -1.0) == approx(0.0)
+
+    def test_round_trip_repay_achieves_target_hf(self):
+        """Apply the computed repayment to a snapshot and verify HF reaches target."""
+        target_hf = 1.25
+        # 10 SOL @ $150, liq_threshold=0.75 => liq_value = 1125
+        # 1000 USDC debt => HF = 1125/1000 = 1.125 (below 1.25)
+        snap = make_snapshot(
+            collateral=[make_collateral("SOL", 10, 150, 0.65, 0.75)],
+            debt=[make_debt("USDC", 1000, 1.0)],
+        )
+        total_debt = snap.total_debt_value()
+        liq_value = snap.liquidation_value()
+
+        repay_amount = recovery_repay_usd(total_debt, liq_value, target_hf)
+        assert repay_amount > 0
+
+        recovered = apply_actions(snap, [
+            {"type": "repay", "symbol": "USDC", "amount": repay_amount},
+        ])
+        assert recovered.health_factor() == approx(target_hf, rel=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# recovery_swap_withdraw
+# ---------------------------------------------------------------------------
+
+class TestRecoverySwapWithdraw:
+    def test_basic_calculation(self):
+        """Basic swap-withdraw amount."""
+        # deficit=500, price=150, target_hf=1.25, liq_threshold=0.75
+        # raw = 500 / (150 * (1.25 - 0.75)) = 500/75 = 6.667
+        result = recovery_swap_withdraw(500, 150, 1.25, 0.75, 100)
+        assert result == approx(500 / 75)
+
+    def test_target_hf_equals_liq_threshold_returns_zero(self):
+        """When target_hf == liq_threshold, swap can't help."""
+        assert recovery_swap_withdraw(500, 150, 0.75, 0.75, 100) == approx(0.0)
+
+    def test_target_hf_below_liq_threshold_returns_zero(self):
+        """When target_hf < liq_threshold, returns 0."""
+        assert recovery_swap_withdraw(500, 150, 0.5, 0.75, 100) == approx(0.0)
+
+    def test_zero_price_returns_zero(self):
+        """Zero collateral price returns 0."""
+        assert recovery_swap_withdraw(500, 0, 1.25, 0.75, 100) == approx(0.0)
+
+    def test_capped_at_max_amount(self):
+        """Result is capped at max_amount when raw exceeds it."""
+        # raw = 500 / (150 * 0.5) = 6.667, max_amount = 3
+        result = recovery_swap_withdraw(500, 150, 1.25, 0.75, 3)
+        assert result == approx(3.0)
+
+    def test_round_trip_swap_withdraw_achieves_target_hf(self):
+        """Withdraw collateral + use proceeds to repay debt => HF reaches target.
+
+        The swap-withdraw formula assumes that withdrawing W tokens of collateral
+        (worth W*price) reduces liq_value by W*price*liq_threshold and simultaneously
+        reduces debt by W*price. Net HF change should hit the target.
+        """
+        target_hf = 1.25
+        sol_price = 150.0
+        liq_threshold = 0.75
+
+        snap = make_snapshot(
+            collateral=[make_collateral("SOL", 20, sol_price, 0.65, liq_threshold)],
+            debt=[make_debt("USDC", 2000, 1.0)],
+        )
+        total_debt = snap.total_debt_value()
+        liq_value = snap.liquidation_value()
+        deficit = compute_deficit(total_debt, liq_value, target_hf)
+
+        withdraw_tokens = recovery_swap_withdraw(
+            deficit, sol_price, target_hf, liq_threshold, 20
+        )
+        withdraw_usd = withdraw_tokens * sol_price
+
+        recovered = apply_actions(snap, [
+            {"type": "withdraw_collateral", "symbol": "SOL", "amount": withdraw_tokens},
+            {"type": "repay", "symbol": "USDC", "amount": withdraw_usd},
+        ])
+        assert recovered.health_factor() == approx(target_hf, rel=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# recovery_deposit_tokens
+# ---------------------------------------------------------------------------
+
+class TestRecoveryDepositTokens:
+    def test_basic_calculation(self):
+        """Basic deposit token calculation."""
+        # deficit=500, price=150, liq_threshold=0.75
+        # deposit = 500 / (150*0.75) = 4.444
+        result = recovery_deposit_tokens(500, 150, 0.75)
+        assert result == approx(500 / (150 * 0.75))
+
+    def test_zero_price_returns_zero(self):
+        assert recovery_deposit_tokens(500, 0, 0.75) == approx(0.0)
+
+    def test_zero_threshold_returns_zero(self):
+        assert recovery_deposit_tokens(500, 150, 0) == approx(0.0)
+
+    def test_round_trip_deposit_achieves_target_hf(self):
+        """Deposit tokens to reach target HF."""
+        target_hf = 1.25
+        sol_price = 150.0
+        liq_threshold = 0.75
+
+        snap = make_snapshot(
+            collateral=[make_collateral("SOL", 10, sol_price, 0.65, liq_threshold)],
+            debt=[make_debt("USDC", 1000, 1.0)],
+        )
+        total_debt = snap.total_debt_value()
+        liq_value = snap.liquidation_value()
+        deficit = compute_deficit(total_debt, liq_value, target_hf)
+
+        deposit_tokens = recovery_deposit_tokens(deficit, sol_price, liq_threshold)
+
+        recovered = apply_actions(snap, [
+            {"type": "deposit_collateral", "symbol": "SOL", "amount": deposit_tokens},
+        ])
+        assert recovered.health_factor() == approx(target_hf, rel=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# auto_loop_deposit
+# ---------------------------------------------------------------------------
+
+class TestAutoLoopDeposit:
+    def test_basic_usdc_to_sol(self):
+        """Borrow USDC, convert to SOL."""
+        # 1000 USDC @ $1, target SOL @ $150 => 1000/150 = 6.667 SOL
+        result = auto_loop_deposit(1000, 1.0, 150.0)
+        assert result == approx(1000 / 150)
+
+    def test_same_asset_prices_equal(self):
+        """Same-price swap => amount unchanged."""
+        result = auto_loop_deposit(100, 1.0, 1.0)
+        assert result == approx(100.0)
+
+    def test_sol_to_sol_same_price(self):
+        """Same-asset loop (SOL@150 -> SOL@150) => 1:1."""
+        result = auto_loop_deposit(5, 150, 150)
+        assert result == approx(5.0)
+
+    def test_zero_target_price_returns_zero(self):
+        assert auto_loop_deposit(1000, 1.0, 0) == approx(0.0)
+
+    def test_negative_target_price_returns_zero(self):
+        assert auto_loop_deposit(1000, 1.0, -10) == approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# collateral_rebalance
+# ---------------------------------------------------------------------------
+
+class TestCollateralRebalance:
+    def test_basic_calculation(self):
+        """Rebalance SOL->USDC at known prices."""
+        # withdraw 5 SOL @ $150, deposit into USDC @ $1 => 750 USDC
+        result = collateral_rebalance(5, 150, 1.0)
+        assert result == approx(750.0)
+
+    def test_same_price_one_to_one(self):
+        """Same price => 1:1 token swap."""
+        result = collateral_rebalance(10, 100, 100)
+        assert result == approx(10.0)
+
+    def test_usd_value_preserved(self):
+        """USD value of withdrawn tokens equals USD value of deposited tokens."""
+        source_price = 150.0
+        target_price = 42.0
+        delta = 7.0
+        deposit_amount = collateral_rebalance(delta, source_price, target_price)
+        assert delta * source_price == approx(deposit_amount * target_price)
+
+    def test_negative_delta_handled(self):
+        """Negative delta treated as absolute value."""
+        result = collateral_rebalance(-5, 150, 1.0)
+        assert result == approx(750.0)
+
+    def test_zero_target_price_returns_zero(self):
+        assert collateral_rebalance(5, 150, 0) == approx(0.0)

--- a/tests/test_kamino_risk.py
+++ b/tests/test_kamino_risk.py
@@ -1,0 +1,499 @@
+"""Comprehensive unit tests for arblab.kamino_risk module."""
+
+import math
+
+import pytest
+
+from arblab.kamino_risk import (
+    apply_actions,
+    liquidation_price_for_collateral,
+    liquidation_price_for_debt,
+    liquidation_prices,
+    scenario_report,
+)
+from tests.conftest import make_collateral, make_debt, make_snapshot
+
+
+# ---------------------------------------------------------------------------
+# 1. Position values (6 tests)
+# ---------------------------------------------------------------------------
+
+
+class TestCollateralPositionValue:
+    def test_value_basic(self):
+        pos = make_collateral(amount=10.0, price=150.0)
+        assert pos.value() == pytest.approx(1500.0)
+
+    def test_liquidation_value(self):
+        pos = make_collateral(amount=10.0, price=150.0, liq_threshold=0.75)
+        assert pos.liquidation_value() == pytest.approx(1125.0)
+
+    def test_borrow_limit_value(self):
+        pos = make_collateral(amount=10.0, price=150.0, ltv=0.65)
+        assert pos.borrow_limit_value() == pytest.approx(975.0)
+
+    def test_zero_amount(self):
+        pos = make_collateral(amount=0.0, price=150.0)
+        assert pos.value() == pytest.approx(0.0)
+        assert pos.liquidation_value() == pytest.approx(0.0)
+        assert pos.borrow_limit_value() == pytest.approx(0.0)
+
+    def test_zero_price(self):
+        pos = make_collateral(amount=10.0, price=0.0)
+        assert pos.value() == pytest.approx(0.0)
+
+    def test_extreme_values(self):
+        pos = make_collateral(amount=1e12, price=1e6, ltv=0.99, liq_threshold=0.99)
+        assert pos.value() == pytest.approx(1e18)
+        assert pos.liquidation_value() == pytest.approx(1e18 * 0.99)
+        assert pos.borrow_limit_value() == pytest.approx(1e18 * 0.99)
+
+
+class TestDebtPositionValue:
+    def test_value_basic(self):
+        pos = make_debt(amount=500.0, price=1.0)
+        assert pos.value() == pytest.approx(500.0)
+
+    def test_zero_amount(self):
+        pos = make_debt(amount=0.0, price=1.0)
+        assert pos.value() == pytest.approx(0.0)
+
+    def test_zero_price(self):
+        pos = make_debt(amount=500.0, price=0.0)
+        assert pos.value() == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# 2. AccountSnapshot metrics (12 tests)
+# ---------------------------------------------------------------------------
+
+
+class TestAccountSnapshotMetrics:
+    def test_total_collateral_value_single(self):
+        snap = make_snapshot(collateral=[make_collateral(amount=10.0, price=150.0)])
+        assert snap.total_collateral_value() == pytest.approx(1500.0)
+
+    def test_total_collateral_value_multi(self):
+        snap = make_snapshot(
+            collateral=[
+                make_collateral(symbol="SOL", amount=10.0, price=150.0),
+                make_collateral(symbol="ETH", amount=2.0, price=3000.0),
+            ]
+        )
+        assert snap.total_collateral_value() == pytest.approx(7500.0)
+
+    def test_total_debt_value_single(self):
+        snap = make_snapshot(debt=[make_debt(amount=500.0, price=1.0)])
+        assert snap.total_debt_value() == pytest.approx(500.0)
+
+    def test_total_debt_value_multi(self):
+        snap = make_snapshot(
+            debt=[
+                make_debt(symbol="USDC", amount=500.0, price=1.0),
+                make_debt(symbol="USDT", amount=300.0, price=1.0),
+            ]
+        )
+        assert snap.total_debt_value() == pytest.approx(800.0)
+
+    def test_liquidation_value_single(self):
+        snap = make_snapshot(
+            collateral=[make_collateral(amount=10.0, price=150.0, liq_threshold=0.75)]
+        )
+        assert snap.liquidation_value() == pytest.approx(1125.0)
+
+    def test_liquidation_value_multi(self):
+        snap = make_snapshot(
+            collateral=[
+                make_collateral(symbol="SOL", amount=10.0, price=150.0, liq_threshold=0.75),
+                make_collateral(symbol="ETH", amount=2.0, price=3000.0, liq_threshold=0.80),
+            ]
+        )
+        # SOL: 1500*0.75=1125, ETH: 6000*0.80=4800 => 5925
+        assert snap.liquidation_value() == pytest.approx(5925.0)
+
+    def test_borrow_limit_multi(self):
+        snap = make_snapshot(
+            collateral=[
+                make_collateral(symbol="SOL", amount=10.0, price=150.0, ltv=0.65),
+                make_collateral(symbol="ETH", amount=2.0, price=3000.0, ltv=0.70),
+            ]
+        )
+        # SOL: 1500*0.65=975, ETH: 6000*0.70=4200 => 5175
+        assert snap.borrow_limit() == pytest.approx(5175.0)
+
+    def test_health_factor_normal(self):
+        snap = make_snapshot(
+            collateral=[make_collateral(amount=10.0, price=150.0, liq_threshold=0.75)],
+            debt=[make_debt(amount=500.0, price=1.0)],
+        )
+        # liq_value=1125, debt=500 => hf=2.25
+        assert snap.health_factor() == pytest.approx(2.25)
+
+    def test_health_factor_no_debt_is_inf(self):
+        snap = make_snapshot(
+            collateral=[make_collateral(amount=10.0, price=150.0)],
+            debt=[],
+        )
+        assert snap.health_factor() == float("inf")
+
+    def test_health_factor_below_one(self):
+        snap = make_snapshot(
+            collateral=[make_collateral(amount=10.0, price=150.0, liq_threshold=0.75)],
+            debt=[make_debt(amount=1200.0, price=1.0)],
+        )
+        # liq_value=1125, debt=1200 => hf=0.9375
+        assert snap.health_factor() == pytest.approx(0.9375)
+
+    def test_current_ltv_normal(self):
+        snap = make_snapshot(
+            collateral=[make_collateral(amount=10.0, price=150.0)],
+            debt=[make_debt(amount=500.0, price=1.0)],
+        )
+        # debt/collateral = 500/1500
+        assert snap.current_ltv() == pytest.approx(500.0 / 1500.0)
+
+    def test_current_ltv_no_collateral_is_inf(self):
+        snap = make_snapshot(
+            collateral=[],
+            debt=[make_debt(amount=500.0, price=1.0)],
+        )
+        assert snap.current_ltv() == float("inf")
+
+    def test_liquidation_buffer_positive(self):
+        snap = make_snapshot(
+            collateral=[make_collateral(amount=10.0, price=150.0, liq_threshold=0.75)],
+            debt=[make_debt(amount=500.0, price=1.0)],
+        )
+        # 1125 - 500 = 625
+        assert snap.liquidation_buffer() == pytest.approx(625.0)
+
+    def test_liquidation_buffer_negative(self):
+        snap = make_snapshot(
+            collateral=[make_collateral(amount=10.0, price=150.0, liq_threshold=0.75)],
+            debt=[make_debt(amount=1200.0, price=1.0)],
+        )
+        # 1125 - 1200 = -75
+        assert snap.liquidation_buffer() == pytest.approx(-75.0)
+
+    def test_liquidation_buffer_zero(self):
+        snap = make_snapshot(
+            collateral=[make_collateral(amount=10.0, price=150.0, liq_threshold=0.75)],
+            debt=[make_debt(amount=1125.0, price=1.0)],
+        )
+        assert snap.liquidation_buffer() == pytest.approx(0.0)
+
+    def test_empty_snapshot(self):
+        snap = make_snapshot()
+        assert snap.total_collateral_value() == pytest.approx(0.0)
+        assert snap.total_debt_value() == pytest.approx(0.0)
+        assert snap.liquidation_value() == pytest.approx(0.0)
+        assert snap.borrow_limit() == pytest.approx(0.0)
+        assert snap.liquidation_buffer() == pytest.approx(0.0)
+        assert snap.current_ltv() == float("inf")
+        assert snap.health_factor() == float("inf")
+
+
+# ---------------------------------------------------------------------------
+# 3. Liquidation price calculators (12 tests)
+# ---------------------------------------------------------------------------
+
+
+class TestLiquidationPriceForCollateral:
+    def test_basic(self):
+        snap = make_snapshot(
+            collateral=[make_collateral(symbol="SOL", amount=10.0, price=150.0, liq_threshold=0.75)],
+            debt=[make_debt(amount=500.0, price=1.0)],
+        )
+        # liq_price = total_debt / (amount * liq_threshold) = 500 / (10*0.75) = 66.666...
+        result = liquidation_price_for_collateral(snap, "SOL")
+        assert result == pytest.approx(500.0 / 7.5)
+
+    def test_multi_collateral(self):
+        snap = make_snapshot(
+            collateral=[
+                make_collateral(symbol="SOL", amount=10.0, price=150.0, liq_threshold=0.75),
+                make_collateral(symbol="ETH", amount=2.0, price=3000.0, liq_threshold=0.80),
+            ],
+            debt=[make_debt(amount=5000.0, price=1.0)],
+        )
+        # other_liq_value for SOL = ETH: 6000*0.80=4800
+        # required = 5000 - 4800 = 200
+        # liq_price = 200 / (10*0.75) = 26.666...
+        result = liquidation_price_for_collateral(snap, "SOL")
+        assert result == pytest.approx(200.0 / 7.5)
+
+    def test_zero_threshold_returns_none(self):
+        snap = make_snapshot(
+            collateral=[make_collateral(symbol="SOL", amount=10.0, price=150.0, liq_threshold=0.0)],
+            debt=[make_debt(amount=500.0, price=1.0)],
+        )
+        assert liquidation_price_for_collateral(snap, "SOL") is None
+
+    def test_zero_amount_returns_none(self):
+        snap = make_snapshot(
+            collateral=[make_collateral(symbol="SOL", amount=0.0, price=150.0, liq_threshold=0.75)],
+            debt=[make_debt(amount=500.0, price=1.0)],
+        )
+        assert liquidation_price_for_collateral(snap, "SOL") is None
+
+    def test_missing_symbol_returns_none(self):
+        snap = make_snapshot(
+            collateral=[make_collateral(symbol="SOL", amount=10.0, price=150.0)],
+            debt=[make_debt(amount=500.0, price=1.0)],
+        )
+        assert liquidation_price_for_collateral(snap, "BTC") is None
+
+    def test_floor_at_zero(self):
+        # When other collateral covers the debt, liquidation price floors at 0
+        snap = make_snapshot(
+            collateral=[
+                make_collateral(symbol="SOL", amount=10.0, price=150.0, liq_threshold=0.75),
+                make_collateral(symbol="ETH", amount=10.0, price=3000.0, liq_threshold=0.80),
+            ],
+            debt=[make_debt(amount=100.0, price=1.0)],
+        )
+        # other_liq_value = 30000*0.80 = 24000 >> 100
+        # required = 100 - 24000 = -23900, max(0, negative) = 0
+        result = liquidation_price_for_collateral(snap, "SOL")
+        assert result == pytest.approx(0.0)
+
+
+class TestLiquidationPriceForDebt:
+    def test_basic(self):
+        snap = make_snapshot(
+            collateral=[make_collateral(symbol="SOL", amount=10.0, price=150.0, liq_threshold=0.75)],
+            debt=[make_debt(symbol="USDC", amount=500.0, price=1.0)],
+        )
+        # liq_price = liq_value / amount = 1125 / 500 = 2.25
+        result = liquidation_price_for_debt(snap, "USDC")
+        assert result == pytest.approx(2.25)
+
+    def test_multi_debt(self):
+        snap = make_snapshot(
+            collateral=[make_collateral(symbol="SOL", amount=10.0, price=150.0, liq_threshold=0.75)],
+            debt=[
+                make_debt(symbol="USDC", amount=500.0, price=1.0),
+                make_debt(symbol="USDT", amount=300.0, price=1.0),
+            ],
+        )
+        # other_debt for USDC = 300
+        # required = 1125 - 300 = 825
+        # liq_price = 825 / 500 = 1.65
+        result = liquidation_price_for_debt(snap, "USDC")
+        assert result == pytest.approx(1.65)
+
+    def test_zero_amount_returns_none(self):
+        snap = make_snapshot(
+            collateral=[make_collateral(symbol="SOL", amount=10.0, price=150.0)],
+            debt=[make_debt(symbol="USDC", amount=0.0, price=1.0)],
+        )
+        assert liquidation_price_for_debt(snap, "USDC") is None
+
+    def test_missing_symbol_returns_none(self):
+        snap = make_snapshot(
+            collateral=[make_collateral(symbol="SOL", amount=10.0, price=150.0)],
+            debt=[make_debt(symbol="USDC", amount=500.0, price=1.0)],
+        )
+        assert liquidation_price_for_debt(snap, "DAI") is None
+
+    def test_floor_at_zero(self):
+        # When other debt already exceeds the liquidation value
+        snap = make_snapshot(
+            collateral=[make_collateral(symbol="SOL", amount=1.0, price=10.0, liq_threshold=0.5)],
+            debt=[
+                make_debt(symbol="USDC", amount=100.0, price=1.0),
+                make_debt(symbol="USDT", amount=1000.0, price=1.0),
+            ],
+        )
+        # liq_value = 10*0.5 = 5, other_debt for USDC = 1000
+        # required = 5 - 1000 = -995, max(0, negative) = 0
+        result = liquidation_price_for_debt(snap, "USDC")
+        assert result == pytest.approx(0.0)
+
+
+class TestLiquidationPricesDict:
+    def test_structure(self):
+        snap = make_snapshot(
+            collateral=[
+                make_collateral(symbol="SOL", amount=10.0, price=150.0, liq_threshold=0.75),
+                make_collateral(symbol="ETH", amount=2.0, price=3000.0, liq_threshold=0.80),
+            ],
+            debt=[
+                make_debt(symbol="USDC", amount=500.0, price=1.0),
+                make_debt(symbol="USDT", amount=300.0, price=1.0),
+            ],
+        )
+        result = liquidation_prices(snap)
+        assert "collateral" in result
+        assert "debt" in result
+        assert set(result["collateral"].keys()) == {"SOL", "ETH"}
+        assert set(result["debt"].keys()) == {"USDC", "USDT"}
+        # Verify values match the individual function calls
+        assert result["collateral"]["SOL"] == pytest.approx(
+            liquidation_price_for_collateral(snap, "SOL")
+        )
+        assert result["debt"]["USDC"] == pytest.approx(
+            liquidation_price_for_debt(snap, "USDC")
+        )
+
+
+# ---------------------------------------------------------------------------
+# 4. apply_actions (11 tests)
+# ---------------------------------------------------------------------------
+
+
+class TestApplyActions:
+    def test_deposit_collateral(self):
+        snap = make_snapshot(
+            collateral=[make_collateral(symbol="SOL", amount=10.0, price=150.0)],
+        )
+        result = apply_actions(snap, [{"type": "deposit_collateral", "symbol": "SOL", "amount": 5.0}])
+        sol = next(p for p in result.collateral if p.symbol == "SOL")
+        assert sol.amount == pytest.approx(15.0)
+
+    def test_withdraw_collateral(self):
+        snap = make_snapshot(
+            collateral=[make_collateral(symbol="SOL", amount=10.0, price=150.0)],
+        )
+        result = apply_actions(snap, [{"type": "withdraw_collateral", "symbol": "SOL", "amount": 3.0}])
+        sol = next(p for p in result.collateral if p.symbol == "SOL")
+        assert sol.amount == pytest.approx(7.0)
+
+    def test_borrow(self):
+        snap = make_snapshot(
+            debt=[make_debt(symbol="USDC", amount=500.0, price=1.0)],
+        )
+        result = apply_actions(snap, [{"type": "borrow", "symbol": "USDC", "amount": 200.0}])
+        usdc = next(p for p in result.debt if p.symbol == "USDC")
+        assert usdc.amount == pytest.approx(700.0)
+
+    def test_repay(self):
+        snap = make_snapshot(
+            debt=[make_debt(symbol="USDC", amount=500.0, price=1.0)],
+        )
+        result = apply_actions(snap, [{"type": "repay", "symbol": "USDC", "amount": 200.0}])
+        usdc = next(p for p in result.debt if p.symbol == "USDC")
+        assert usdc.amount == pytest.approx(300.0)
+
+    def test_set_price_updates_collateral_and_debt(self):
+        snap = make_snapshot(
+            collateral=[make_collateral(symbol="SOL", amount=10.0, price=150.0)],
+            debt=[make_debt(symbol="SOL", amount=5.0, price=150.0)],
+        )
+        result = apply_actions(snap, [{"type": "set_price", "symbol": "SOL", "price": 200.0}])
+        col_sol = next(p for p in result.collateral if p.symbol == "SOL")
+        debt_sol = next(p for p in result.debt if p.symbol == "SOL")
+        assert col_sol.price == pytest.approx(200.0)
+        assert debt_sol.price == pytest.approx(200.0)
+
+    def test_update_price_updates_collateral_and_debt(self):
+        snap = make_snapshot(
+            collateral=[make_collateral(symbol="SOL", amount=10.0, price=150.0)],
+            debt=[make_debt(symbol="SOL", amount=5.0, price=150.0)],
+        )
+        result = apply_actions(snap, [{"type": "update_price", "symbol": "SOL", "price": 180.0}])
+        col_sol = next(p for p in result.collateral if p.symbol == "SOL")
+        debt_sol = next(p for p in result.debt if p.symbol == "SOL")
+        assert col_sol.price == pytest.approx(180.0)
+        assert debt_sol.price == pytest.approx(180.0)
+
+    def test_missing_collateral_symbol_raises(self):
+        snap = make_snapshot(
+            collateral=[make_collateral(symbol="SOL", amount=10.0, price=150.0)],
+        )
+        with pytest.raises(ValueError, match="Collateral asset BTC not found"):
+            apply_actions(snap, [{"type": "deposit_collateral", "symbol": "BTC", "amount": 1.0}])
+
+    def test_missing_debt_symbol_raises(self):
+        snap = make_snapshot(
+            debt=[make_debt(symbol="USDC", amount=500.0, price=1.0)],
+        )
+        with pytest.raises(ValueError, match="Debt asset DAI not found"):
+            apply_actions(snap, [{"type": "borrow", "symbol": "DAI", "amount": 100.0}])
+
+    def test_unknown_action_raises(self):
+        snap = make_snapshot(
+            collateral=[make_collateral(symbol="SOL", amount=10.0, price=150.0)],
+        )
+        with pytest.raises(ValueError, match="Unknown action type"):
+            apply_actions(snap, [{"type": "liquidate", "symbol": "SOL", "amount": 1.0}])
+
+    def test_set_price_missing_price_raises(self):
+        snap = make_snapshot(
+            collateral=[make_collateral(symbol="SOL", amount=10.0, price=150.0)],
+        )
+        with pytest.raises(ValueError, match="Price is required"):
+            apply_actions(snap, [{"type": "set_price", "symbol": "SOL"}])
+
+    def test_multiple_sequential_actions(self):
+        snap = make_snapshot(
+            collateral=[make_collateral(symbol="SOL", amount=10.0, price=150.0, ltv=0.65, liq_threshold=0.75)],
+            debt=[make_debt(symbol="USDC", amount=500.0, price=1.0)],
+        )
+        result = apply_actions(snap, [
+            {"type": "deposit_collateral", "symbol": "SOL", "amount": 5.0},
+            {"type": "repay", "symbol": "USDC", "amount": 100.0},
+            {"type": "set_price", "symbol": "SOL", "price": 200.0},
+        ])
+        sol = next(p for p in result.collateral if p.symbol == "SOL")
+        usdc = next(p for p in result.debt if p.symbol == "USDC")
+        assert sol.amount == pytest.approx(15.0)
+        assert sol.price == pytest.approx(200.0)
+        assert usdc.amount == pytest.approx(400.0)
+
+    def test_immutability(self):
+        original_collateral = make_collateral(symbol="SOL", amount=10.0, price=150.0)
+        original_debt = make_debt(symbol="USDC", amount=500.0, price=1.0)
+        snap = make_snapshot(
+            collateral=[original_collateral],
+            debt=[original_debt],
+        )
+        apply_actions(snap, [
+            {"type": "deposit_collateral", "symbol": "SOL", "amount": 5.0},
+            {"type": "repay", "symbol": "USDC", "amount": 100.0},
+        ])
+        # Original snapshot should be unchanged
+        assert snap.collateral[0].amount == pytest.approx(10.0)
+        assert snap.debt[0].amount == pytest.approx(500.0)
+
+
+# ---------------------------------------------------------------------------
+# 5. scenario_report (2 tests)
+# ---------------------------------------------------------------------------
+
+
+class TestScenarioReport:
+    def test_has_all_keys(self):
+        snap = make_snapshot(
+            collateral=[make_collateral(symbol="SOL", amount=10.0, price=150.0, ltv=0.65, liq_threshold=0.75)],
+            debt=[make_debt(symbol="USDC", amount=500.0, price=1.0)],
+        )
+        report = scenario_report(snap)
+        expected_keys = {
+            "total_collateral_value",
+            "total_debt_value",
+            "borrow_limit",
+            "current_ltv",
+            "health_factor",
+            "liquidation_buffer",
+        }
+        assert set(report.keys()) == expected_keys
+
+    def test_values_match_direct_calls(self):
+        snap = make_snapshot(
+            collateral=[
+                make_collateral(symbol="SOL", amount=10.0, price=150.0, ltv=0.65, liq_threshold=0.75),
+                make_collateral(symbol="ETH", amount=2.0, price=3000.0, ltv=0.70, liq_threshold=0.80),
+            ],
+            debt=[
+                make_debt(symbol="USDC", amount=500.0, price=1.0),
+                make_debt(symbol="USDT", amount=300.0, price=1.0),
+            ],
+        )
+        report = scenario_report(snap)
+        assert report["total_collateral_value"] == pytest.approx(snap.total_collateral_value())
+        assert report["total_debt_value"] == pytest.approx(snap.total_debt_value())
+        assert report["borrow_limit"] == pytest.approx(snap.borrow_limit())
+        assert report["current_ltv"] == pytest.approx(snap.current_ltv())
+        assert report["health_factor"] == pytest.approx(snap.health_factor())
+        assert report["liquidation_buffer"] == pytest.approx(snap.liquidation_buffer())

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -1,0 +1,457 @@
+"""Exotic multi-step DeFi scenario tests for the Kamino Risk Simulator.
+
+Each test is marked with @pytest.mark.scenario.
+"""
+
+import pytest
+from pytest import approx
+
+from tests.conftest import make_collateral, make_debt, make_snapshot
+from arblab.kamino_risk import apply_actions, AccountSnapshot, liquidation_price_for_collateral
+from arblab.kamino_recovery import (
+    auto_loop_deposit,
+    compute_deficit,
+    recovery_deposit_tokens,
+    recovery_repay_usd,
+)
+
+
+# ---------------------------------------------------------------------------
+# 1. JitoSOL short hedge cushions a SOL drop
+# ---------------------------------------------------------------------------
+
+@pytest.mark.scenario
+def test_jitosol_short_hedge_cushions_sol_drop():
+    """Borrowing JitoSOL as a hedge: HF drops less than unhedged when SOL falls 30%.
+
+    Both positions start identically. The hedged version then borrows 5 JitoSOL
+    and deposits the USD proceeds as USDG collateral. When SOL & JitoSOL drop 30%,
+    the JitoSOL debt shrinks, cushioning the HF decline.
+    """
+    sol_price = 150.0
+    jitosol_price = 155.0  # JitoSOL trades at slight premium
+    usdg_price = 1.0
+
+    # Shared base parameters: 20 SOL collateral, 1000 USDG collateral, 2000 USDC debt
+    base_debt_amount = 2000.0
+
+    # Branch A: hedged -- borrow 5 JitoSOL (worth 775 USD), deposit 775 USDG
+    jitosol_borrow_tokens = 5
+    jitosol_usd_value = jitosol_borrow_tokens * jitosol_price  # 775
+    hedged = make_snapshot(
+        collateral=[
+            make_collateral("SOL", 20, sol_price, 0.65, 0.75),
+            make_collateral("USDG", 1000 + jitosol_usd_value, usdg_price, 0.80, 0.85),
+        ],
+        debt=[
+            make_debt("USDC", base_debt_amount, 1.0),
+            make_debt("JitoSOL", jitosol_borrow_tokens, jitosol_price),
+        ],
+    )
+
+    # Branch B: unhedged -- same base, no JitoSOL borrow
+    unhedged = make_snapshot(
+        collateral=[
+            make_collateral("SOL", 20, sol_price, 0.65, 0.75),
+            make_collateral("USDG", 1000, usdg_price, 0.80, 0.85),
+        ],
+        debt=[
+            make_debt("USDC", base_debt_amount, 1.0),
+        ],
+    )
+
+    # Record HF before crash
+    hedged_hf_before = hedged.health_factor()
+    unhedged_hf_before = unhedged.health_factor()
+
+    # SOL & JitoSOL drop 30% (correlated)
+    hedged_after = apply_actions(hedged, [
+        {"type": "set_price", "symbol": "SOL", "price": sol_price * 0.7},
+        {"type": "set_price", "symbol": "JitoSOL", "price": jitosol_price * 0.7},
+    ])
+    unhedged_after = apply_actions(unhedged, [
+        {"type": "set_price", "symbol": "SOL", "price": sol_price * 0.7},
+    ])
+
+    # HF drop for hedged should be smaller than unhedged
+    hedged_drop = hedged_hf_before - hedged_after.health_factor()
+    unhedged_drop = unhedged_hf_before - unhedged_after.health_factor()
+    assert hedged_drop < unhedged_drop
+
+
+# ---------------------------------------------------------------------------
+# 2. SOL leverage loop -- three iterations
+# ---------------------------------------------------------------------------
+
+@pytest.mark.scenario
+def test_sol_leverage_loop_three_iterations():
+    """3x leverage loop: borrow USDC -> buy SOL -> deposit. Total SOL > 200, 1 < HF < 2."""
+    sol_price = 150.0
+    snap = make_snapshot(
+        collateral=[make_collateral("SOL", 100, sol_price, 0.65, 0.75)],
+        debt=[make_debt("USDC", 0, 1.0)],
+    )
+
+    for _ in range(3):
+        borrow_limit = snap.borrow_limit() - snap.total_debt_value()
+        borrow_usd = borrow_limit * 0.90  # borrow 90% of remaining limit
+        new_sol = auto_loop_deposit(borrow_usd, 1.0, sol_price)
+
+        snap = apply_actions(snap, [
+            {"type": "borrow", "symbol": "USDC", "amount": borrow_usd},
+            {"type": "deposit_collateral", "symbol": "SOL", "amount": new_sol},
+        ])
+
+    total_sol = next(p for p in snap.collateral if p.symbol == "SOL").amount
+    assert total_sol > 200
+    assert 1.0 < snap.health_factor() < 2.0
+
+
+# ---------------------------------------------------------------------------
+# 3. USDC de-peg benefits the borrower
+# ---------------------------------------------------------------------------
+
+@pytest.mark.scenario
+def test_usdc_depeg_benefits_borrower():
+    """SOL collateral + USDC debt: USDC drops to $0.90 => HF improves."""
+    snap = make_snapshot(
+        collateral=[make_collateral("SOL", 10, 150, 0.65, 0.75)],
+        debt=[make_debt("USDC", 800, 1.0)],
+    )
+    hf_before = snap.health_factor()
+
+    depegged = apply_actions(snap, [
+        {"type": "set_price", "symbol": "USDC", "price": 0.90},
+    ])
+    assert depegged.health_factor() > hf_before
+
+
+# ---------------------------------------------------------------------------
+# 4. USDC de-peg hurts the depositor
+# ---------------------------------------------------------------------------
+
+@pytest.mark.scenario
+def test_usdc_depeg_hurts_depositor():
+    """USDC collateral + USDT debt: USDC drops to $0.90 => HF drops."""
+    snap = make_snapshot(
+        collateral=[make_collateral("USDC", 1000, 1.0, 0.80, 0.85)],
+        debt=[make_debt("USDT", 800, 1.0)],
+    )
+    hf_before = snap.health_factor()
+
+    depegged = apply_actions(snap, [
+        {"type": "set_price", "symbol": "USDC", "price": 0.90},
+    ])
+    assert depegged.health_factor() < hf_before
+
+
+# ---------------------------------------------------------------------------
+# 5. Collateral price to zero
+# ---------------------------------------------------------------------------
+
+@pytest.mark.scenario
+def test_collateral_price_to_zero():
+    """SOL goes to $0 => HF near 0, buffer deeply negative."""
+    snap = make_snapshot(
+        collateral=[make_collateral("SOL", 10, 150, 0.65, 0.75)],
+        debt=[make_debt("USDC", 500, 1.0)],
+    )
+
+    crashed = apply_actions(snap, [
+        {"type": "set_price", "symbol": "SOL", "price": 0.0},
+    ])
+
+    assert crashed.health_factor() == approx(0.0)
+    assert crashed.liquidation_buffer() == approx(-500.0)
+
+
+# ---------------------------------------------------------------------------
+# 6. Multi-collateral: one wipes out, other remains
+# ---------------------------------------------------------------------------
+
+@pytest.mark.scenario
+def test_multi_collateral_one_wipes_out():
+    """SOL goes to $0 but USDC collateral remains. HF depends only on USDC."""
+    snap = make_snapshot(
+        collateral=[
+            make_collateral("SOL", 10, 150, 0.65, 0.75),
+            make_collateral("USDC", 1000, 1.0, 0.80, 0.85),
+        ],
+        debt=[make_debt("USDT", 500, 1.0)],
+    )
+
+    crashed = apply_actions(snap, [
+        {"type": "set_price", "symbol": "SOL", "price": 0.0},
+    ])
+
+    # Only USDC liq_value remains: 1000 * 0.85 = 850
+    expected_hf = 850.0 / 500.0
+    assert crashed.health_factor() == approx(expected_hf)
+
+
+# ---------------------------------------------------------------------------
+# 7. Whale position: 1M SOL
+# ---------------------------------------------------------------------------
+
+@pytest.mark.scenario
+def test_whale_million_sol():
+    """1M SOL ($150M collateral), $80M USDC debt. No overflow, HF calculable."""
+    snap = make_snapshot(
+        collateral=[make_collateral("SOL", 1_000_000, 150, 0.65, 0.75)],
+        debt=[make_debt("USDC", 80_000_000, 1.0)],
+    )
+
+    hf = snap.health_factor()
+    # liq_value = 1e6 * 150 * 0.75 = 112_500_000
+    expected_hf = 112_500_000 / 80_000_000
+    assert hf == approx(expected_hf)
+    assert hf > 1.0
+
+
+# ---------------------------------------------------------------------------
+# 8. Dust position
+# ---------------------------------------------------------------------------
+
+@pytest.mark.scenario
+def test_dust_position():
+    """Extremely small position: no float weirdness."""
+    snap = make_snapshot(
+        collateral=[make_collateral("SOL", 0.000001, 150, 0.65, 0.75)],
+        debt=[make_debt("USDC", 0.0001, 1.0)],
+    )
+
+    hf = snap.health_factor()
+    # liq_value = 0.000001 * 150 * 0.75 = 0.0001125
+    expected = 0.0001125 / 0.0001
+    assert hf == approx(expected)
+    assert snap.liquidation_buffer() == approx(0.0001125 - 0.0001)
+
+
+# ---------------------------------------------------------------------------
+# 9. Price crash -> recover -> crash again
+# ---------------------------------------------------------------------------
+
+@pytest.mark.scenario
+def test_price_crash_recover_crash_again():
+    """SOL drops to $100, recover via repay, SOL drops to $70. State is consistent."""
+    target_hf = 1.25
+    snap = make_snapshot(
+        collateral=[make_collateral("SOL", 10, 150, 0.65, 0.75)],
+        debt=[make_debt("USDC", 1000, 1.0)],
+    )
+
+    # First crash: SOL to $100
+    crashed1 = apply_actions(snap, [
+        {"type": "set_price", "symbol": "SOL", "price": 100.0},
+    ])
+    assert crashed1.health_factor() < target_hf
+
+    # Recover: repay enough to reach target
+    deficit1 = compute_deficit(
+        crashed1.total_debt_value(), crashed1.liquidation_value(), target_hf
+    )
+    repay1 = recovery_repay_usd(
+        crashed1.total_debt_value(), crashed1.liquidation_value(), target_hf
+    )
+    recovered = apply_actions(crashed1, [
+        {"type": "repay", "symbol": "USDC", "amount": repay1},
+    ])
+    assert recovered.health_factor() == approx(target_hf, rel=1e-9)
+
+    # Second crash: SOL to $70
+    crashed2 = apply_actions(recovered, [
+        {"type": "set_price", "symbol": "SOL", "price": 70.0},
+    ])
+    assert crashed2.health_factor() < target_hf
+
+    # Can still compute a new recovery
+    repay2 = recovery_repay_usd(
+        crashed2.total_debt_value(), crashed2.liquidation_value(), target_hf
+    )
+    assert repay2 > 0
+    final = apply_actions(crashed2, [
+        {"type": "repay", "symbol": "USDC", "amount": repay2},
+    ])
+    assert final.health_factor() == approx(target_hf, rel=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# 10. Correlated pair: SOL + mSOL drop 20%
+# ---------------------------------------------------------------------------
+
+@pytest.mark.scenario
+def test_correlated_pair_sol_msol_drop():
+    """SOL + mSOL (mSOL = 1.05*SOL). Both drop 20%. HF drop is proportional."""
+    sol_price = 150.0
+    msol_price = sol_price * 1.05  # 157.5
+
+    snap = make_snapshot(
+        collateral=[
+            make_collateral("SOL", 10, sol_price, 0.65, 0.75),
+            make_collateral("mSOL", 10, msol_price, 0.65, 0.75),
+        ],
+        debt=[make_debt("USDC", 1500, 1.0)],
+    )
+    hf_before = snap.health_factor()
+
+    dropped = apply_actions(snap, [
+        {"type": "set_price", "symbol": "SOL", "price": sol_price * 0.8},
+        {"type": "set_price", "symbol": "mSOL", "price": msol_price * 0.8},
+    ])
+    hf_after = dropped.health_factor()
+
+    # Both collateral values dropped 20%, debt unchanged.
+    # New liq_value = 0.8 * old_liq_value, so new HF = 0.8 * old HF
+    assert hf_after == approx(hf_before * 0.8, rel=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# 11. Auto-loop after crash improves HF
+# ---------------------------------------------------------------------------
+
+@pytest.mark.scenario
+def test_auto_loop_after_crash_improves_hf():
+    """SOL crashes to $120, borrow USDC, auto-loop into SOL.
+
+    Leverage looping with liq_threshold < 1 always pulls HF toward
+    1/liq_threshold. When HF > 1/liq_threshold it decreases; the test
+    verifies more SOL exposure while HF stays safely above 1.
+    """
+    snap = make_snapshot(
+        collateral=[make_collateral("SOL", 20, 150, 0.65, 0.75)],
+        debt=[make_debt("USDC", 800, 1.0)],
+    )
+
+    # Crash SOL to $120
+    crashed = apply_actions(snap, [
+        {"type": "set_price", "symbol": "SOL", "price": 120.0},
+    ])
+    hf_before = crashed.health_factor()
+    # HF = 20*120*0.75 / 800 = 1800/800 = 2.25
+
+    # Auto-loop: borrow 300 USDC, buy SOL at $120
+    borrow_usd = 300.0
+    new_sol = auto_loop_deposit(borrow_usd, 1.0, 120.0)
+
+    looped = apply_actions(crashed, [
+        {"type": "borrow", "symbol": "USDC", "amount": borrow_usd},
+        {"type": "deposit_collateral", "symbol": "SOL", "amount": new_sol},
+    ])
+
+    hf_after = looped.health_factor()
+    sol_after = next(p for p in looped.collateral if p.symbol == "SOL").amount
+    assert sol_after > 20  # more SOL exposure
+    assert hf_after > 1.0  # still safe
+    assert hf_after < hf_before  # leverage increased risk as expected
+
+
+# ---------------------------------------------------------------------------
+# 12. Adding collateral lowers liquidation price
+# ---------------------------------------------------------------------------
+
+@pytest.mark.scenario
+def test_adding_collateral_lowers_liq_price():
+    """Add USDC collateral => SOL liquidation price decreases."""
+    snap = make_snapshot(
+        collateral=[
+            make_collateral("SOL", 10, 150, 0.65, 0.75),
+            make_collateral("USDC", 0, 1.0, 0.80, 0.85),
+        ],
+        debt=[make_debt("USDT", 800, 1.0)],
+    )
+    liq_price_before = liquidation_price_for_collateral(snap, "SOL")
+
+    added = apply_actions(snap, [
+        {"type": "deposit_collateral", "symbol": "USDC", "amount": 500},
+    ])
+    liq_price_after = liquidation_price_for_collateral(added, "SOL")
+
+    assert liq_price_after < liq_price_before
+
+
+# ---------------------------------------------------------------------------
+# 13. HF exactly one
+# ---------------------------------------------------------------------------
+
+@pytest.mark.scenario
+def test_hf_exactly_one():
+    """Engineer HF = 1.0 exactly. Buffer should be 0."""
+    # Need liq_value == total_debt.
+    # 10 SOL @ $100 with liq_threshold = 0.80 => liq_value = 800
+    # debt = 800 => HF = 1.0
+    snap = make_snapshot(
+        collateral=[make_collateral("SOL", 10, 100, 0.65, 0.80)],
+        debt=[make_debt("USDC", 800, 1.0)],
+    )
+
+    assert snap.health_factor() == approx(1.0)
+    assert snap.liquidation_buffer() == approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# 14. HF just below one
+# ---------------------------------------------------------------------------
+
+@pytest.mark.scenario
+def test_hf_just_below_one():
+    """HF = ~0.9999. Buffer slightly negative."""
+    # liq_value = 10 * 100 * 0.80 = 800, debt = 800.08
+    snap = make_snapshot(
+        collateral=[make_collateral("SOL", 10, 100, 0.65, 0.80)],
+        debt=[make_debt("USDC", 800.08, 1.0)],
+    )
+
+    assert snap.health_factor() < 1.0
+    assert snap.health_factor() == approx(800 / 800.08, rel=1e-6)
+    assert snap.liquidation_buffer() < 0
+
+
+# ---------------------------------------------------------------------------
+# 15. Sequential recovery: partial deposit then full repay
+# ---------------------------------------------------------------------------
+
+@pytest.mark.scenario
+def test_sequential_recovery_partial_then_full():
+    """HF drops, deposit half needed collateral, then repay remaining debt to reach target."""
+    target_hf = 1.30
+    sol_price = 150.0
+    liq_threshold = 0.75
+
+    snap = make_snapshot(
+        collateral=[make_collateral("SOL", 10, sol_price, 0.65, liq_threshold)],
+        debt=[make_debt("USDC", 1000, 1.0)],
+    )
+
+    # Crash SOL to $100
+    crashed = apply_actions(snap, [
+        {"type": "set_price", "symbol": "SOL", "price": 100.0},
+    ])
+    assert crashed.health_factor() < target_hf
+
+    # Step 1: deposit half the needed SOL collateral
+    deficit = compute_deficit(
+        crashed.total_debt_value(), crashed.liquidation_value(), target_hf
+    )
+    full_deposit = recovery_deposit_tokens(deficit, 100.0, liq_threshold)
+    half_deposit = full_deposit / 2.0
+
+    partial = apply_actions(crashed, [
+        {"type": "deposit_collateral", "symbol": "SOL", "amount": half_deposit},
+    ])
+    # After partial deposit, HF is better but not at target yet
+    assert partial.health_factor() < target_hf
+    assert partial.health_factor() > crashed.health_factor()
+
+    # Step 2: repay remaining debt to reach target
+    remaining_deficit = compute_deficit(
+        partial.total_debt_value(), partial.liquidation_value(), target_hf
+    )
+    assert remaining_deficit > 0
+    repay_amount = recovery_repay_usd(
+        partial.total_debt_value(), partial.liquidation_value(), target_hf
+    )
+
+    final = apply_actions(partial, [
+        {"type": "repay", "symbol": "USDC", "amount": repay_amount},
+    ])
+    assert final.health_factor() == approx(target_hf, rel=1e-9)


### PR DESCRIPTION
### Motivation
- Provide the simulator with the ability to load a Kamino obligation from-chain and compute liquidation/health metrics instead of requiring manual JSON input. 
- Decode Anchor-based accounts so the tool can operate against live Solana data for realistic risk simulations. 
- Expose a CLI that accepts either a JSON input or an on-chain obligation with program id and IDL for flexible workflows. 
- Capture next steps for continued work in a `CONTINUATION.md` so a following agent can complete on-chain program/IDL discovery and run an end-to-end simulation. 

### Description
- Add `arblab/kamino_onchain.py` which implements lightweight Solana RPC helpers (`_rpc_call`, `_get_account`), Anchor IDL loading and decoding (`_load_idl`, `_decode_account`), reserve parsing (`_parse_reserve_config`), and `load_onchain_snapshot` to return an `AccountSnapshot`. 
- Add `arblab/kamino_risk.py` which defines `CollateralPosition`, `DebtPosition`, `AccountSnapshot` dataclasses and core risk functions `liquidation_prices`, `apply_actions`, and `scenario_report`. 
- Add `kamino_sim.py` CLI that accepts `--input` JSON or `--obligation`/`--program-id`/`--idl`/`--rpc-url` and builds a simulation payload from either source, then prints baseline and post-action scenario reports. 
- Add `kamino_sample.json` as a local payload example, update `requirements.txt` to include `anchorpy` and `solana`, clean up `arblab/__init__.py` to remove the stale import, and add `CONTINUATION.md` containing a step-by-step prompt for the next agent to discover the program ID, fetch the Anchor IDL, and run the CLI (example: `python kamino_sim.py --obligation <ADDR> --program-id <PROGRAM_ID> --idl kamino_idl.json --rpc-url https://api.mainnet-beta.solana.com`). 

### Testing
- No automated tests or CI were executed for these changes. 
- The change includes code that was exercised via manual/local smoke checks during development, but no formal unit or integration tests were run as part of this commit.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986764d57e08333bec44894e940c257)